### PR TITLE
Refactor Ant buildfile

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -94,19 +94,6 @@ See the accompanying license.txt file for applicable licenses.
     <property name="args.filter" location="${ditaval.file}"/>
   </target>
 
-  <target name="site">
-    <local name="site.out.dir"/>
-    <property name="site.out.dir" location="${doc.out.dir}/site"/>
-
-    <dita-ot transtype="net.sourceforge.dita-ot.html" input="site.ditamap" output="${site.out.dir}">
-      <properties>
-        <property name="args.gen.task.lbl" value="YES"/>
-        <property name="args.input" value="site.ditamap"/>
-        <property name="args.rellinks" value="all"/>
-      </properties>
-    </dita-ot>
-  </target>
-
   <target name="pdf">
     <dita-ot transtype="pdf" input="userguide-book.ditamap" output="${doc.out.dir}">
       <properties>
@@ -152,6 +139,6 @@ See the accompanying license.txt file for applicable licenses.
     <delete dir="${ditaval.file}" failonerror="false"/>
   </target>
 
-  <target name="all" depends="pdf, html, htmlhelp, site"/>
+  <target name="all" depends="pdf, html, htmlhelp"/>
 
 </project>

--- a/site.xml
+++ b/site.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+See the accompanying license.txt file for applicable licenses.
+-->
+<project name="site" default="site" basedir=".">
+
+  <import file="build.xml"/>
+
+  <target name="site">
+    <local name="site.out.dir"/>
+    <property name="site.out.dir" location="${doc.out.dir}/site"/>
+
+    <dita-ot transtype="net.sourceforge.dita-ot.html" input="site.ditamap" output="${site.out.dir}">
+      <properties>
+        <property name="args.gen.task.lbl" value="YES"/>
+        <property name="args.input" value="site.ditamap"/>
+        <property name="args.rellinks" value="all"/>
+      </properties>
+    </dita-ot>
+  </target>
+
+</project>


### PR DESCRIPTION
The buildfile now assumes that the user is in the `docsrc` of a DITA-OT distribution.

I've also moved the `site` target into a separate buildfile.
