### PR TITLE
Use sentence-style capitalization in titles

### DIFF
--- a/dev_ref/migrating-to-1.5.4.dita
+++ b/dev_ref/migrating-to-1.5.4.dita
@@ -4,7 +4,7 @@
 
 <reference id="ID" rev="1.5.4">
 
-  <title>Migrating to Release 1.5.4</title>
+  <title>Migrating to release 1.5.4</title>
 
   <shortdesc>DITA-OT 1.5.4 adds new extension points to configure behavior based on file extensions, declare print
     transformation types and add mappings to the PDF configuration catalog file. PDF output supports mirrored page

--- a/dev_ref/migrating-to-1.6.dita
+++ b/dev_ref/migrating-to-1.6.dita
@@ -4,7 +4,7 @@
 
 <reference id="ID" rev="1.6">
 
-  <title>Migrating to Release 1.6</title>
+  <title>Migrating to release 1.6</title>
 
   <shortdesc>In DITA-OT 1.6, various <filepath>demo</filepath> plugins were removed along with many deprecated
     properties, targets, templates and modes. The PDF2 transformation no longer supports the beta version of DITA from

--- a/dev_ref/migrating-to-1.7.dita
+++ b/dev_ref/migrating-to-1.7.dita
@@ -4,7 +4,7 @@
 
 <reference id="ID" rev="1.7">
 
-  <title>Migrating to Release 1.7</title>
+  <title>Migrating to release 1.7</title>
 
   <shortdesc>In DITA-OT 1.7, a new preprocessing step implements flagging for HTML-based output formats. PDF processing
     was corrected with regard to <codeph>shortdesc</codeph> handling, and a new XSLT template mode was introduced for

--- a/dev_ref/migrating-to-1.8.dita
+++ b/dev_ref/migrating-to-1.8.dita
@@ -4,7 +4,7 @@
 
 <reference id="ID" rev="1.8">
 
-  <title>Migrating to Release 1.8</title>
+  <title>Migrating to release 1.8</title>
 
   <shortdesc>In DITA-OT 1.8, certain stylesheets were moved to plug-in specific folders and various deprecated Ant
     properties, XSLT stylesheets, parameters and modes were removed from the XHTML, PDF and ODT

--- a/dev_ref/plugin-xmlcatalog.dita
+++ b/dev_ref/plugin-xmlcatalog.dita
@@ -3,7 +3,7 @@
 <!--This file is part of the DITA Open Toolkit project. See the accompanying LICENSE.md file for applicable licenses.-->
 
 <reference id="plugin-xmlcatalog" xml:lang="en-US">
-  <title>Extending the XML Catalog</title>
+  <title>Extending the XML catalog</title>
   <shortdesc>The XML Catalogs extension point is used to update the XML Catalogs used to resolve DTD or Schema document
     types, or to add URI mappings. This is required in order to support DITA specializations or new DITA document type
     shells.</shortdesc>

--- a/user-guide/pdf2-creating-change-bars.dita
+++ b/user-guide/pdf2-creating-change-bars.dita
@@ -3,7 +3,7 @@
 <!--This file is part of the DITA Open Toolkit project. See the accompanying LICENSE.md file for applicable licenses.-->
 
 <concept id="concept_gsc_vcf_vs">
-  <title>Creating Change Bars</title>
+  <title>Creating change bars</title>
   <shortdesc>The PDF2 transform can generate change (revision) bars with XSL-FO engines that support the fo:change-bar
     formatting object.</shortdesc>
   <conbody>


### PR DESCRIPTION
Per The IBM Style Guide, topic titles should use sentence-style
capitalization. Most of the DITA-OT docs currently aligns with the style
guidelines.