### PR TITLE
Remove a comment containing code that is not relevant anymore

### DIFF
--- a/user-guide/DITA_v1-3-support.dita
+++ b/user-guide/DITA_v1-3-support.dita
@@ -15,12 +15,6 @@
       unversioned DITA doctypes to the 1.3 DTDs. All processing ordinarily dependent on the 1.0, 1.1, or 1.2 definitions
       continues to work as usual, and any documents that make use of the newer DITA 1.3 elements or attributes will be
       supported with specific new processing.</p>
-    <!--
-    <p>Because this support is based on a yet-to-be-approved (Candidate OASIS Standard 01) version of the proposed
-      <xref keyref="dita-ot-spec"/>, if you choose to investigate any 1.3-based function, be aware that the 1.3
-      implementation in this version of the toolkit is preliminary. Upon final approval of the DITA 1.3 standard,
-      toolkit developers will review the implementation to make certain that it conforms to the final specification.</p>
-    -->
     <section>
       <title>Initial Preview Support for DITA 1.3 in DITA-OT 2.0</title>
       <p>The following DITA 1.3 features were implemented in version 2.0 of the toolkit. Issue numbers correspond to the


### PR DESCRIPTION
Remove commented code that is not relevant now, as the DITA 1.3 is a released specification.