### PR TITLE
Remove mention of @translate

### DIFF
--- a/user-guide/DITA-globalization.dita
+++ b/user-guide/DITA-globalization.dita
@@ -6,6 +6,6 @@
   <title>Globalizing DITA content</title>
   <shortdesc>The DITA standard supports content that is written in or translated to any language. In general, the DITA
     Open Toolkit passes content through to the output format unchanged. The DITA-OT uses the values for the
-      <xmlatt>xml:lang</xmlatt>, <xmlatt>translate</xmlatt>, and <xmlatt>dir</xmlatt> attributes that are set in the
+      <xmlatt>xml:lang</xmlatt> and <xmlatt>dir</xmlatt> attributes that are set in the
     source content to provide globalization support.</shortdesc>
 </task>


### PR DESCRIPTION
I don't think the toolkit actually uses `@translate` in default processing -- it's definitely a useful DITA attribute for globalization, but I can't think of how our default processing would use it or change based on its value.