### PR TITLE
Add cross reference to configuration option

### DIFF
--- a/user-guide/globalization-supported-in-dita-ot.dita
+++ b/user-guide/globalization-supported-in-dita-ot.dita
@@ -26,13 +26,13 @@
         <dlentry>
           <dt>Bi-directional text</dt>
           <dd>The DITA-OT contains style sheets (CSS files) that support both left-to-right (LTR) and right-to-left
-            (RTL) languages.<draft-comment author="Kristen James Eberlein" time="11 August 2012">What support is offered
-              by the legacypdf and pdf2 transformations?</draft-comment></dd>
+            (RTL) languages in HTML based transformations. PDF supports both LTR and RTL rendering based on the document language.
+            The <xmlatt>dir</xmlatt> attribute can be used to override the default rendering direction.</dd>
         </dlentry>
       </dl>When the DITA-OT generates output, it takes the first value for the <xmlatt>xml:lang</xmlatt> attribute that
       it encounters, and then it uses that value to create generated text, perform index sorting, and determine which
       default CSS file is used. If no value for the <xmlatt>xml:lang</xmlatt> attribute is found, the toolkit defaults
-      to US English.<draft-comment author="Kristen James Eberlein" time="11 August 2012">Does the DITA-OT also use the
-        values for the <xmlatt>dir</xmlatt> attribute?</draft-comment></p>
+      to US English. You can use the <xref href="../parameters/configuration-properties.dita">configuration.properties</xref>
+      to change the default language.</p>
   </conbody>
 </concept>


### PR DESCRIPTION
Updated to add cross reference to configuration.properties, which can be used to change the default language.

Also noticed and addressed a couple of draft comments from Kris.