### PR TITLE
Update saxon-gradle plugin version to 0.2.1

### DIFF
--- a/site.gradle
+++ b/site.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.eerohele.dita-ot-gradle' version '0.4.0'
-    id 'com.github.eerohele.saxon-gradle' version '0.1.3'
+    id 'com.github.eerohele.saxon-gradle' version '0.2.1'
 }
 
 import com.github.eerohele.SaxonXsltTask
@@ -18,7 +18,7 @@ def ditaHomeSrc = project.hasProperty("ditaHomeSrc") ? file("${ditaHomeSrc}") : 
 def resourceDir = "$ditaHomeSrc/resources"
 
 def toURI(String directory) {
-  new URI(new File(directory).getAbsolutePath()).toString()
+  new File(directory).toURI().toString()
 }
 
 task messages(type: SaxonXsltTask) {
@@ -32,7 +32,7 @@ task params(type: SaxonXsltTask) {
   output "parameters/all-parameters.dita"
   stylesheet "resources/params.xsl"
 
-  parameters("output-dir.url": project.toURI("parameters"))
+  parameters("output-dir.url": toURI("parameters"))
 
   outputs.dir "${projectDir}/parameters"
 }
@@ -42,7 +42,7 @@ task extensionPoints(type: SaxonXsltTask) {
   output "extension-points/all-extension-points.dita"
   stylesheet "resources/extension-points.xsl"
 
-  parameters("output-dir.url": project.toURI("extension-points"))
+  parameters("output-dir.url": toURI("extension-points"))
 
   outputs.dir "${projectDir}/extension-points"
 }


### PR DESCRIPTION
0.2.1 fixes the rather confusing (to the user of the plugin) issue https://github.com/eerohele/saxon-gradle/issues/5.

In `site.gradle`, the issue manifested in having to call `project.toURI` instead of just `toURI`, so I've modified those instances as well.

I also refactored the `toURI` function to work correctly on Windows.