### PR TITLE
Tweaking technically innacurate (obsolete) info

### DIFF
--- a/dev_ref/plugin-newtranstype.dita
+++ b/dev_ref/plugin-newtranstype.dita
@@ -54,7 +54,8 @@
   &lt;feature extension="dita.transtype.print" value="newtext"/>
   &lt;feature extension="dita.conductor.target.relative" file="build-newtext.xml"/>
 &lt;/plugin></codeblock>
-      <p>The following example shows how the <filepath>org.dita.html5</filepath> plug-in uses the
+      <p>While the <filepath>org.dita.html5</filepath> plug-in was separated from <codeph>common-html</codeph> in version 2.4,
+          the following example shows how earlier versions of that plug-in used the
           <xmlelement>transtype</xmlelement> element to extend the common HTML transformation with a new
           <option>html5</option> transformation type and define a new <parmname>nav-toc</parmname> parameter with three
         possible values:</p>


### PR DESCRIPTION
The docs currently use HTML5 as an example that extends another transform, but as of 2.4 this is no longer true. I've tweaked the language to point out that this remains a good example, but technically applies to earlier versions of that plugin.

Potential longer term alternatives: create a full example, use XHTML (which is much longer and sort of out of date), or HTML Help (which is really short but REALLY out of date), or just use an abbreviated version of another plugin.