### PR TITLE
Note in performance section that OT 2.4 requires Java 8

### DIFF
--- a/user-guide/reducing-processing-time.dita
+++ b/user-guide/reducing-processing-time.dita
@@ -35,7 +35,9 @@
       </section>
       <section>
          <title>Use the latest Java version</title>
-         <p>DITA-OT 2.0 requires Java 7, but using the latest version Java 8 will further reduce processing time.</p>
+         <p>DITA-OT 2.0 to 2.3 require Java Runtime Environment (JRE) 7, and DITA-OT 2.4 and newer require JRE 8.
+            However, using a newer version of the JRE with these versions of DITA-OT can further reduce processing
+            time.</p>
       </section>
    </body>
 


### PR DESCRIPTION
[DITA-OT 2.4 and newer require Java 8.](http://www.dita-ot.org/2.4/release-notes/index.html#ID__requirements) Noting that DITA-OT 2.0 requires Java 7 without including this context can lead to confusion if this is the first page of documentation a user encounters.