### PR TITLE
Map common parameters to arguments

### DIFF
--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -77,9 +77,11 @@
             <parmname>-i</parmname>
             <varname>file</varname>
           </pt>
-          <pd id="args.input.desc">Specifies the master file for your documentation project. Typically this is a DITA
-            map, however it also can be a DITA topic if you want to transform a single DITA file. The path can be
-            absolute, relative to <parmname>args.input.dir</parmname>, or relative to the current directory if
+          <pd id="args.input.desc">Specifies the master file for your documentation project. This
+            argument corresponds to the common parameter <parmname>args.input</parmname>. Typically
+            this is a DITA map, however it also can be a DITA topic if you want to transform a
+            single DITA file. The path can be absolute, relative to
+              <parmname>args.input.dir</parmname>, or relative to the current directory if
               <parmname>args.input.dir</parmname> is not defined.</pd>
         </plentry>
         <plentry>
@@ -142,16 +144,19 @@
             <parmname>-o</parmname>
             <varname>dir</varname>
           </pt>
-          <pd id="output.dir.desc">Specifies the path of the output directory; the path can be absolute or relative to
-            the current directory. By default, the output is written to the <filepath>out</filepath> subdirectory of the
-            current directory.</pd>
+          <pd id="output.dir.desc">Specifies the path of the output directory; the path can be
+            absolute or relative to the current directory. This argument corresponds to the common
+            parameter <parmname>output.dir</parmname>. By default, the output is written to the
+              <filepath>out</filepath> subdirectory of the current directory.</pd>
         </plentry>
         <plentry>
           <pt>
             <parmname>--filter</parmname>=<varname>file</varname>
           </pt>
-          <pd>Specifies filter file(s) used to include, exclude, or flag content.</pd>
-          <pd>Relative paths are resolved against the current directory and internally converted to absolute paths.</pd>
+          <pd>Specifies filter file(s) used to include, exclude, or flag content. </pd>
+          <pd>This argument corresponds to the common parameter <parmname>args.filter</parmname>.
+            Relative paths are resolved against the current directory and internally converted to
+            absolute paths.</pd>
         </plentry>
         <plentry>
           <pt>
@@ -161,6 +166,8 @@
             <varname>dir</varname>
           </pt>
           <pd conref="parameters-base.dita#base/dita.temp.dir.desc"/>
+          <pd>This argument corresponds to the common parameter
+            <parmname>dita.temp.dir</parmname>.</pd>
         </plentry>
         <plentry>
           <pt>
@@ -193,10 +200,11 @@
           <pt>
             <parmname>-D</parmname><varname>parameter</varname>=<varname>value</varname>
           </pt>
-          <pd>Specify a value for a DITA-OT or Ant build parameter.
-            <p>The GNU-style <parmname>--parameter</parmname>=<varname>value</varname> form is only available for
-              parameters that are configured in the plug-in configuration file; the Java-style <parmname>-D</parmname>
-              form can also be used to specify additional non-configured parameters or set system properties.</p>
+          <pd>Specify a value for a DITA-OT or Ant build parameter. <p>The GNU-style
+                <parmname>--parameter</parmname>=<varname>value</varname> form is only available for
+              parameters that are configured in the plug-in configuration file; the Java-style
+                <parmname>-D</parmname> form can also be used to specify additional non-configured
+              parameters or set system properties.</p>
             <p>Parameters not implemented by the specified transformation type or referenced in a
                 <filepath>.properties</filepath> file are ignored.</p><note
               conref="../resources/conref-task.dita#ID/pass-input-dir"/></pd>

--- a/resources/conref-task.dita
+++ b/resources/conref-task.dita
@@ -51,8 +51,10 @@
             <li id="novice-variables-2"><varname>input-file</varname> is the DITA map or DITA file that you want to
               process.</li>
             <li id="novice-variables-last" audience="novice">
-              <p id="common-format-info"><varname>format</varname> is the output format (transformation type). Use the
-                same values available for the <parmname>transtype</parmname> build parameter, for example,
+              <p id="common-format-info"><varname>format</varname> is the output format
+                (transformation type). This argument corresponds to the common parameter
+                  <parmname>transtype</parmname>. Use the same values available for the
+                  <parmname>transtype</parmname> build parameter, for example,
                   <option>html5</option> or <option>pdf</option>.</p>
             </li>
             <li id="expert-variables-last" audience="expert">
@@ -70,8 +72,9 @@
                 </ul>
               </p>
             </li>
-            <li id="options"><varname>options</varname> include the following optional build parameters:
-              <parml conref="../parameters/dita-command-arguments.dita#dita-command-properties/dita_build_options">
+            <li id="options"><varname>options</varname> include the following optional build
+              parameters: <parml
+                conref="../parameters/dita-command-arguments.dita#dita-command-properties/dita_build_options">
                 <plentry>
                   <pt/>
                   <pd/>


### PR DESCRIPTION
It would be easier for starters, if the docs would name the corresponding parameters for the dita command arguments.