### PR TITLE
Refactor build to use `dita` command

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,6 +25,7 @@
     <attribute name="transtype"/>
     <attribute name="input"/>
     <attribute name="output"/>
+    <attribute name="propertyfile"/>
 
     <element name="properties" optional="yes"/>
 
@@ -36,12 +37,19 @@
         <target name="generate-properties-file"/>
       </antcall>
 
+      <!--
       <ant antfile="${dita.home}/build.xml">
         <property name="args.input" location="@{input}"/>
         <property name="output.dir" location="@{output}"/>
         <property name="transtype" value="@{transtype}"/>
         <properties/>
       </ant>
+      -->
+
+      <exec executable="${dita.home}/bin/dita">
+        <arg line="--input=@{input} --format=@{transtype} --output=@{output} --propertyfile=@{propertyfile}"/>
+      </exec>
+
     </sequential>
   </macrodef>
 
@@ -139,27 +147,27 @@
   </target>
 
   <target name="pdf">
-    <dita-ot transtype="pdf" input="userguide-book.ditamap" output="${doc.out.dir}">
+    <dita-ot transtype="pdf" input="userguide-book.ditamap" output="${doc.out.dir}"
+             propertyfile="samples/properties/docs-build-pdf.properties">
       <properties>
-        <property file="samples/properties/docs-build-pdf.properties"/>
         <property name="conserve-memory" value="true"/>
       </properties>
     </dita-ot>
   </target>
 
   <target name="html">
-    <dita-ot transtype="html5" input="userguide.ditamap" output="${doc.out.dir}">
+    <dita-ot transtype="html5" input="userguide.ditamap" output="${doc.out.dir}"
+             propertyfile="samples/properties/docs-build-html5.properties">
       <properties>
-        <property file="samples/properties/docs-build-html5.properties"/>
         <property name="conserve-memory" value="true"/>
       </properties>
     </dita-ot>
   </target>
 
   <target name="htmlhelp">
-    <dita-ot transtype="htmlhelp" input="userguide.ditamap" output="${doc.out.dir}/htmlhelp">
+    <dita-ot transtype="htmlhelp" input="userguide.ditamap" output="${doc.out.dir}/htmlhelp"
+             propertyfile="samples/properties/docs-build-htmlhelp.properties">
       <properties>
-        <property file="samples/properties/docs-build-htmlhelp.properties"/>
         <property name="conserve-memory" value="true"/>
       </properties>
     </dita-ot>

--- a/build.xml
+++ b/build.xml
@@ -47,7 +47,7 @@
       -->
 
       <exec executable="${dita.home}/bin/dita">
-        <arg line="--input=@{input} --format=@{transtype} --output=@{output} --propertyfile=@{propertyfile}"/>
+        <arg line="--input=@{input} --format=@{transtype} --output=@{output} --propertyfile=@{propertyfile} -Dargs.input.dir=${basedir}"/>
       </exec>
 
     </sequential>

--- a/samples/properties/docs-build-html5.properties
+++ b/samples/properties/docs-build-html5.properties
@@ -2,19 +2,16 @@
 args.copycss = yes
 
 # Custom .css file used to style output:
-args.css = dita-ot-doc.css
+args.css = ${args.input.dir}/resources/dita-ot-doc.css
 
 # Location of the copied .css file relative to the output:
 args.csspath = css
-
-# Directory that contains the custom .css file:
-args.cssroot = resources
 
 # Generate headings for sections within task topics:
 args.gen.task.lbl = YES
 
 # File that contains the running header content:
-args.hdr = ${basedir}/resources/header.xml
+args.hdr = ${args.input.dir}/resources/header.xml
 
 # Base name of the Table of Contents file:
 args.html5.toc = toc


### PR DESCRIPTION
This PR refactors the distribution docs build to use the `dita` command to pick up the classpath settings and new library dependencies required by external plug-ins.

It is not intended to be merged yet 'as is', but rather to serve as a basis for discussion on the best way to refactor the build to meet the new requirements.

One open issue with this approach is that the `.properties` files used in earlier releases used `${basedir}` to anchor the absolute paths required for parameters such as `args.hdr`, as in [docs-build-html5.properties](https://github.com/dita-ot/docs/blob/develop/samples/properties/docs-build-html5.properties#L17).

@jelovirt The `${basedir}` approach worked with Ant, but throws errors when building with the `dita` command. How can we define portable paths for parameters that require absolute values?