### PR TITLE
Clean up topics on DITA 1.2 and DITA 1.3

### DIFF
--- a/resources/external-links.ditamap
+++ b/resources/external-links.ditamap
@@ -63,6 +63,13 @@
         <linktext>documentation contributions</linktext>
       </topicmeta>
     </keydef>
+<keydef keys="dita13-issues"
+href="https://github.com/dita-ot/dita-ot/issues?q=label%3A%22DITA+1.3%22" scope="external"
+format="html">
+<topicmeta>
+<linktext>GitHub issues tagged with DITA 1.3</linktext>
+</topicmeta>
+</keydef>
   </topicset>
 
   <topicset
@@ -211,33 +218,91 @@
   <topicset
     id="specs"
     navtitle="Specs and RFC links">
-    <keydef
-      keys="dita-ot-spec"
-      href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html"
-      scope="external"
-      format="html">
-      <topicmeta>
-        <linktext>DITA 1.3 specification</linktext>
-      </topicmeta>
-    </keydef>
-    <keydef
-      keys="dita-ot-spec-metadata-cascade"
-      href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/cascading-in-a-ditamap.html#cascading-in-a-ditamap"
-      scope="external"
-      format="html">
-      <topicmeta>
-        <linktext>DITA 1.3 specification: Cascading of metadata attributes in a DITA map</linktext>
-      </topicmeta>
-    </keydef>
-    <keydef
-      keys="dita-ot-spec-metadata-cascade-example"
-      href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/example-how-cascade-att-functions.html"
-      scope="external"
-      format="html">
-      <topicmeta>
-        <linktext>Example: How the @cascade attribute functions</linktext>
-      </topicmeta>
-    </keydef>
+<topicset id="dita13spec">
+<keydef keys="dita-ot-spec"
+href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html" scope="external"
+format="html">
+<topicmeta>
+<linktext>DITA 1.3 specification</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-all-inclusive"
+href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.html" scope="external"
+format="html">
+<topicmeta>
+<linktext>DITA 1.3 Part 3 latest errata version: All-Inclusive Edition (HTML)</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-all-inclusive-pdf"
+href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.pdf" scope="external"
+format="pdf">
+<topicmeta>
+<linktext>DITA 1.3 Part 3 latest errata version: All-Inclusive Edition (PDF)</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-source"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/dita-v1.3-errata01-os-part3-all-inclusive-complete-dita.zip"
+scope="external" format="zip">
+<topicmeta>
+<linktext>DITA Version 1.3 Errata 01 (Distribution ZIP of the DITA source)</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita-ot-spec-metadata-cascade"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/cascading-in-a-ditamap.html#cascading-in-a-ditamap"
+scope="external" format="html">
+<topicmeta>
+<linktext>DITA 1.3 specification: Cascading of metadata attributes in a DITA map</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita-ot-spec-metadata-cascade-example"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/example-how-cascade-att-functions.html"
+scope="external" format="html">
+<topicmeta>
+<linktext>Example: How the @cascade attribute functions</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-keyscopes"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/keyScopes.html"
+format="html" scope="external">
+<topicmeta>
+<linktext>DITA 1.3 specification: Scoped keys</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-branch-filter"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/branch-filtering.html"
+format="html" scope="external">
+<topicmeta>
+<linktext>DITA 1.3 specification: Branch filtering</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita13-spec-profile-groups"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/usage-of-conditional-processing-attributes.html"
+format="html" scope="external">
+<topicmeta>
+<linktext>DITA 1.3 specification: Branch filtering</linktext>
+</topicmeta>
+</keydef>
+</topicset>
+<topicset id="dita12">
+<keydef keys="dita12-xhtml" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.html"
+scope="external" format="html">
+<topicmeta>
+<linktext>DITA 1.2 Specification (XHTML)</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita12-pdf" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.pdf"
+scope="external" format="pdf">
+<topicmeta>
+<linktext>DITA 1.2 Specification (PDF)</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita12-source" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.zip"
+scope="external" format="zip">
+<topicmeta>
+<linktext>DITA 1.2 Specification (DITA source)</linktext>
+</topicmeta>
+</keydef>
+</topicset>
     <keydef
       keys="fo-spec"
       scope="external"
@@ -352,6 +417,19 @@
   <topicset
     id="websites"
     navtitle="Other Websites">
+<keydef keys="dita-tc" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita"
+format="html" scope="external">
+<topicmeta>
+<linktext>OASIS DITA Technical Committee</linktext>
+</topicmeta>
+</keydef>
+<keydef keys="dita-adoption-tc"
+href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita-adoption" scope="external"
+format="html">
+<topicmeta>
+<linktext>OASIS DITA Adoption Technical Committee</linktext>
+</topicmeta>
+</keydef>
     <keydef
       keys="sass-lang"
       href="http://sass-lang.com"

--- a/user-guide/DITA_v1-2-support.dita
+++ b/user-guide/DITA_v1-2-support.dita
@@ -5,9 +5,9 @@
 <concept id="dita1.2specification" xml:lang="en-US">
   <title>DITA 1.2 support</title>
   <shortdesc>DITA Open Toolkit <keyword keyref="release"/> supports the DITA 1.2 specification.
-Although 1.2 is no longer the latest version of DITA, grammar files (DTD and XML Schema), the
-grammar files are still included with DITA-OT so that content explicitly created for 1.2 continues
-to work.</shortdesc>
+While 1.2 is no longer the latest version of DITA, grammar files (DTD and XML Schema), the grammar
+files are still included with DITA-OT and content explicitly created for 1.2 continues to work as
+intended.</shortdesc>
   <conbody>
     <p>Highlights of DITA 1.2 support in the toolkit include:<ul>
         <li>Processing support for all new elements and attributes</li>
@@ -34,21 +34,9 @@ specification is geared more towards tool implementors, though both may be usefu
 audience. The DITA Adoption papers can be found from that committee's main web page.</p>
   </conbody>
   <related-links>
-    <link format="html" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.html" scope="external">
-      <linktext>DITA 1.2 Specification (XHTML)</linktext>
-    </link>
-    <link format="pdf" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.pdf" scope="external">
-      <linktext>DITA 1.2 Specification (PDF)</linktext>
-    </link>
-    <link format="zip" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.zip" scope="external">
-      <linktext>DITA 1.2 Specification (zip of the DITA source)</linktext>
-    </link>
-    <link format="zip" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec-chm.zip" scope="external">
-      <linktext>DITA 1.2 Specification (zip of the HTML Help)</linktext>
-    </link>
-    <link format="html" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita-adoption" scope="external">
-      <linktext>DITA Adoption Technical Committee</linktext>
-      <desc>Contains links to many white papers about using new DITA 1.2 features.</desc>
-    </link>
+<link keyref="dita12-xhtml"/>
+<link keyref="dita12-pdf"/>
+<link keyref="dita12-source"/>
+<link keyref="dita-adoption-tc"/>
   </related-links>
 </concept>

--- a/user-guide/DITA_v1-2-support.dita
+++ b/user-guide/DITA_v1-2-support.dita
@@ -4,28 +4,21 @@
 
 <concept id="dita1.2specification" xml:lang="en-US">
   <title>DITA 1.2 support</title>
-  <shortdesc>DITA Open Toolkit <keyword keyref="release"/> supports the DITA 1.2 specification. Initial support for this
-    specification was added in version 1.5 of the toolkit; versions 1.5.1 and 1.5.2 contain minor modifications to keep
-    up with the latest drafts. The specification itself was approved at approximately the same time as DITA-OT 1.5.2,
-    which contained the final versions of the DTD and Schemas. DITA-OT 1.6 updated the DITA 1.2 XSDs to address minor
-    errata in the standard; the DTDs remain up to date.</shortdesc>
+  <shortdesc>DITA Open Toolkit <keyword keyref="release"/> supports the DITA 1.2 specification.
+Although 1.2 is no longer the latest version of DITA, grammar files (DTD and XML Schema), the
+grammar files are still included with DITA-OT so that content explicitly created for 1.2 continues
+to work.</shortdesc>
   <conbody>
-    <p>Earlier versions of the DITA Open Toolkit contained a subset of the specification material, including
-      descriptions of each DITA element. This material was shipped in source, CHM and PDF format. This was possible in
-      part because versions 1.0 and 1.1 of the DITA Specification contained two separate specification documents: one
-      for the architectural specification, and one for the language specification.</p>
-    <p>In DITA 1.2, each of these has been considerably expanded, and the two have been combined into a single document.
-      The overall document is much larger, and including the same set of material would double the size of the DITA-OT
-      package. Rather than include that material in the package, we’ve provided the links below to the latest
-      specification material.</p>
     <p>Highlights of DITA 1.2 support in the toolkit include:<ul>
         <li>Processing support for all new elements and attributes</li>
-        <li>Link redirection and text replacement using keyref</li>
-        <li>New processing-role attribute in maps to allow references to topics that will not produce output
-          artifacts</li>
-        <li>New conref extensions, including the ability to reference a range of elements, to push content into another
-          topic, and to use keys for resolving a conref attribute.</li>
-        <li>The ability to filter content with controlled values and taxonomies, using the new Subject Scheme Map</li>
+        <li>Link redirection and text replacement using <xmlatt>keyref</xmlatt></li>
+        <li>New <xmlatt>processing-role</xmlatt> attribute in maps to allow references to topics
+that will not produce output artifacts</li>
+        <li>New content reference extensions, including the ability to reference a range of
+elements, to push content into another topic, and to use keys for resolving a
+<xmlatt>conref</xmlatt> attribute.</li>
+        <li>The ability to filter content with controlled values and taxonomies using Subject Scheme
+Maps</li>
         <li>Processing support for both default versions of task (original, limited task, and the general task with
           fewer constraints on element order)</li>
         <li>Acronym and abbreviation support with the new <xmlelement>abbreviated-form</xmlelement> element</li>
@@ -34,11 +27,11 @@
           toolkit contains only basic processing support for these, but can be extended to produce related artifacts
           such as SCORM modules)</li>
       </ul></p>
-    <p>To find detailed information about any of these features, see the specification documents at OASIS. The DITA
-      Adoption Technical Committee has also produced several papers to describe individual new features. In general, the
-      white papers are geared more towards DITA users and authors, while the specification is geared more towards tool
-      implementors, though both may be useful for either audience. The DITA Adoption papers can be found from that TC’s
-      main web page.</p>
+    <p>To find detailed information about any of these features, see the specification documents at
+OASIS. The DITA Adoption Technical Committee has also produced several papers to describe individual
+new features. In general, the white papers are geared more towards DITA users and authors, while the
+specification is geared more towards tool implementors, though both may be useful for either
+audience. The DITA Adoption papers can be found from that committee's main web page.</p>
   </conbody>
   <related-links>
     <link format="html" href="http://docs.oasis-open.org/dita/v1.2/spec/DITA1.2-spec.html" scope="external">
@@ -56,11 +49,6 @@
     <link format="html" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita-adoption" scope="external">
       <linktext>DITA Adoption Technical Committee</linktext>
       <desc>Contains links to many white papers about using new DITA 1.2 features.</desc>
-    </link>
-    <link format="html" href="http://dita.xml.org/wiki/dita-12-specification-building-specification-subsets"
-      scope="external">
-      <linktext>Building subsets of the specification</linktext>
-      <desc>Information about how to build subsets of the specification using the DITA Open Toolkit.</desc>
     </link>
   </related-links>
 </concept>

--- a/user-guide/DITA_v1-3-support.dita
+++ b/user-guide/DITA_v1-3-support.dita
@@ -20,14 +20,10 @@ specific new processing.</p>
       <title>Major features of DITA 1.3</title>
 <p>The following DITA 1.3 features are supported in DITA Open Toolkit.</p>
       <ul>
-<li><xref
-href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/keyScopes.html"
-format="html" scope="external">Scoped keys</xref> supported using DITA 1.3 <xmlatt>keyscope</xmlatt>
-attribute</li>
-<li><xref
-href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/branch-filtering.html"
-format="html" scope="external">Branch filtering</xref> using <xmlelement>ditavalref</xmlelement>
-elements in a map</li>
+<li><xref keyref="dita13-spec-keyscope">Scoped keys</xref> supported using DITA 1.3
+<xmlatt>keyscope</xmlatt> attribute</li>
+<li><xref keyref="dita13-spec-branch-filter">Branch filtering</xref> using
+<xmlelement>ditavalref</xmlelement> elements in a map</li>
 <li>Support formatting based on new XML Mention elements, such as adding angle brackets around
 elements tagged with <xmlelement>xmlelement</xmlelement> and adding <codeph>@</codeph> before
 attributes tagged with <xmlelement>xmlatt</xmlelement></li>
@@ -35,9 +31,8 @@ attributes tagged with <xmlelement>xmlatt</xmlelement></li>
 <xmlelement>overline</xmlelement></li>
 <li>Support for profiling based on <xmlatt>deliveryTarget</xmlatt> attribute</li>
 <li>Support for the new <xmlatt>orient</xmlatt> attribute for rotating tables</li>
-<li>Profile (filter or flag) based on  <xref
-href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/usage-of-conditional-processing-attributes.html#usage-of-conditional-processing-attributes"
-format="html" scope="external">groups within profiling attributes</xref></li>
+<li>Profile (filter or flag) based on  <xref keyref="dita13-spec-profile-groups">groups within
+profiling attributes</xref></li>
 <li><xmlatt>keyref</xmlatt> and related key referencing attributes supported on
 <xmlelement>object</xmlelement></li>
         <li>New in-topic link syntax using <codeph>.</codeph> in place of the topic ID:
@@ -49,30 +44,14 @@ grouping</li>
 cascade operation</xref> described by the DITA Specification)</li>
       </ul>
 <note>For the latest status information on DITA 1.3-related features and fixes, see the <xref
-href="https://github.com/dita-ot/dita-ot/issues?q=label%3A%22DITA+1.3%22" scope="external"
-format="html">DITA 1.3 label</xref> in the GitHub issues tracker.</note>
+keyref="dita13-issues">DITA 1.3 label</xref> in the GitHub issues tracker.</note>
     </section>
   </conbody>
 
   <related-links>
-    <link format="html"
-href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.html "
-scope="external">
-<linktext>DITA Version 1.3 Part 3 (latest errata version): All-Inclusive Edition (HTML)</linktext>
-</link>
-    <link format="pdf"
-href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.pdf" scope="external">
-<linktext>DITA Version 1.3 Part 3 (latest errata version): All-Inclusive Edition (PDF)</linktext>
-</link>
-    <link format="zip"
-href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/dita-v1.3-errata01-os-part3-all-inclusive-complete-dita.zip"
-scope="external">
-<linktext>DITA Version 1.3 Errata 01 (Distribution ZIP of the DITA source)</linktext>
-</link>
-    <link format="html" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita-adoption"
-      scope="external">
-      <linktext>DITA Adoption Technical Committee</linktext>
-      <desc>Contains links to many white papers about using new DITA 1.3 features.</desc>
-    </link>
+<link keyref="dita13-spec-all-inclusive"/>
+<link keyref="dita13-spec-all-inclusive-pdf"/>
+<link keyref="dita13-spec-source"/>
+<link keyref="dita-adoption-tc"/>
   </related-links>
 </concept>

--- a/user-guide/DITA_v1-3-support.dita
+++ b/user-guide/DITA_v1-3-support.dita
@@ -4,96 +4,71 @@
 
 <concept id="dita-13-spec-support" xml:lang="en-US">
   <title>DITA 1.3 support</title>
-  <shortdesc><ph id="shortdesc-ph">DITA Open Toolkit <keyword keyref="release"/> provides processing support for the
-      OASIS DITA 1.3 specification. Initial preview support for this specification was added in version 2.0 of the
-      toolkit; version 2.2 extends this foundation to support key scopes and branch filtering along with additional DITA
-      1.3 features.</ph></shortdesc>
+  <shortdesc><ph id="shortdesc-ph">DITA Open Toolkit <keyword keyref="release"/> provides processing
+support for the OASIS DITA 1.3 specification. Initial preview support for this specification was
+added in version 2.0 of the toolkit; version 2.2 extended this foundation to support key scopes and
+branch filtering along with additional DITA 1.3 features.</ph></shortdesc>
 
   <conbody>
-    <p id="p">Because DITA 1.3 is fully backwards compatible with previous DITA DTDs and schemas, DITA-OT 2.2 provides
-      the 1.3 materials as the default DTDs for processing. The XML Catalog resolution maps any references for
-      unversioned DITA doctypes to the 1.3 DTDs. All processing ordinarily dependent on the 1.0, 1.1, or 1.2 definitions
-      continues to work as usual, and any documents that make use of the newer DITA 1.3 elements or attributes will be
-      supported with specific new processing.</p>
+    <p id="p">Because DITA 1.3 is fully backwards compatible with previous DITA DTDs and schemas,
+DITA-OT provides the 1.3 materials as the default grammar files for processing. The XML Catalog
+resolution maps any references for unversioned DITA document types to the 1.3 versions. All
+processing ordinarily dependent on the 1.0, 1.1, or 1.2 definitions continues to work as usual, and
+any documents that make use of the newer DITA 1.3 elements or attributes will be supported with
+specific new processing.</p>
     <section>
-      <title>Initial Preview Support for DITA 1.3 in DITA-OT 2.0</title>
-      <p>The following DITA 1.3 features were implemented in version 2.0 of the toolkit. Issue numbers correspond to the
-        tracking number in the
-        <xref keyref="dita-ot-issues"/>.</p>
+      <title>Major features of DITA 1.3</title>
+<p>The following DITA 1.3 features are supported in DITA Open Toolkit.</p>
       <ul>
-        <li>Support DITA 1.3 link syntax (milestone 2)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1649" format="html" scope="external">#1649</xref></li>
-        <li>Support DITA 1.3 cascade attribute (milestone 2)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1636" format="html" scope="external">#1636</xref></li>
-        <li>Implement DITA 1.3 profiling (milestone 2)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1635" format="html" scope="external">#1635</xref></li>
-        <li>Add new DITA 1.3 highlighting elements (milestone 4)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1651" format="html" scope="external">#1651</xref></li>
-        <li>Add DITA 1.3 markup and xml domain support (milestone 4)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1652" format="html" scope="external">#1652</xref></li>
-        <li>Add DITA 1.3 <xmlelement>div</xmlelement> element (milestone 4)
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1654" format="html" scope="external">#1654</xref></li>
+<li><xref
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/keyScopes.html"
+format="html" scope="external">Scoped keys</xref> supported using DITA 1.3 <xmlatt>keyscope</xmlatt>
+attribute</li>
+<li><xref
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/branch-filtering.html"
+format="html" scope="external">Branch filtering</xref> using <xmlelement>ditavalref</xmlelement>
+elements in a map</li>
+<li>Support formatting based on new XML Mention elements, such as adding angle brackets around
+elements tagged with <xmlelement>xmlelement</xmlelement> and adding <codeph>@</codeph> before
+attributes tagged with <xmlelement>xmlatt</xmlelement></li>
+<li>New highlighting elements <xmlelement>line-through</xmlelement> and
+<xmlelement>overline</xmlelement></li>
+<li>Support for profiling based on <xmlatt>deliveryTarget</xmlatt> attribute</li>
+<li>Support for the new <xmlatt>orient</xmlatt> attribute for rotating tables</li>
+<li>Profile (filter or flag) based on  <xref
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/usage-of-conditional-processing-attributes.html#usage-of-conditional-processing-attributes"
+format="html" scope="external">groups within profiling attributes</xref></li>
+<li><xmlatt>keyref</xmlatt> and related key referencing attributes supported on
+<xmlelement>object</xmlelement></li>
+        <li>New in-topic link syntax using <codeph>.</codeph> in place of the topic ID:
+<codeph>#./figure</codeph></li>
+<li>Support for additional new elements, such as the <xmlelement>div</xmlelement> element for
+grouping</li>
+<li>Support <xmlatt>cascade</xmlatt> attribute in maps (processing defaults to the value
+<codeph>merge</codeph>, which is the <xref keyref="dita-ot-spec-metadata-cascade-example">default
+cascade operation</xref> described by the DITA Specification)</li>
       </ul>
-    </section>
-
-    <section>
-      <title>Additional DITA 1.3 support in DITA-OT 2.2</title>
-      <p>The following DITA 1.3 features were implemented in version 2.2 of the toolkit.</p>
-      <note type="important" id="2094">The DITA 1.3 grammars are now used as the default DTDs for processing
-        <xref href="https://github.com/dita-ot/dita-ot/issues/2094" scope="external" format="html">#2094</xref></note>
-      <ul>
-        <li id="1969">Initial implementation of DITA 1.3 branch filtering
-          <xref href="https://github.com/dita-ot/dita-ot/pull/1969" scope="external" format="html">#1969</xref>,
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1637" scope="external" format="html">#1637</xref>
-          <p>The implementation is a separate module that is run before keyref processing. The process
-            <ul>
-              <li>Splits branches so that each branch contains a single ditavalref </li>
-              <li>Generates <xmlatt>copy-to</xmlatt> attributes for each branch-generated
-                  <xmlelement>topicref</xmlelement>
-              </li>
-              <li>Filters the map based on branch filters </li>
-              <li>Rewrites duplicate generated copy-to targets with a numbered <tt>-#</tt> suffix </li>
-              <li>Copies and filters generated copy-to targets </li>
-              <li>Filters topics that were not branch-generated </li>
-            </ul>
-          </p>
-        </li>
-        <li id="1979">Initial support for DITA 1.3 key scopes, including multiple scope names in a single
-            <xmlatt>keyscope</xmlatt> attribute
-          <xref href="https://github.com/dita-ot/dita-ot/pull/1979" scope="external" format="html">#1979</xref>,
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1648" scope="external" format="html">#1648</xref>,
-          <xref href="https://github.com/dita-ot/dita-ot/issues/2004" scope="external" format="html">#2004</xref>
-        </li>
-        <li id="1783">The <xmlatt>keyref</xmlatt> attribute is now supported on <xmlelement>object</xmlelement> elements
-          <xref href="https://github.com/dita-ot/dita-ot/issues/1783" scope="external" format="html">#1783</xref>
-        </li>
-        <li id="1968">Processing order has been revised to process any same topic fragments used in conrefs before the
-          conref phase, to enable content references to elements in the same topic using a reference such as
-            <codeph>&lt;p&#xA0;conref="#./ID"/></codeph> as reported in
-          <xref href="https://github.com/dita-ot/dita-ot/pull/1649" scope="external" format="html">#1649</xref>.
-          <xref href="https://github.com/dita-ot/dita-ot/pull/1968" scope="external" format="html">#1968</xref>
-        </li>
-      </ul>
-      <note>For the latest status information on DITA 1.3-related features, see the
-        <xref href="https://github.com/dita-ot/dita-ot/issues?q=label%3A%22DITA+1.3%22+is%3Aclosed" scope="external"
-          format="html">DITA 1.3 label</xref> in the GitHub issues tracker.</note>
+<note>For the latest status information on DITA 1.3-related features and fixes, see the <xref
+href="https://github.com/dita-ot/dita-ot/issues?q=label%3A%22DITA+1.3%22" scope="external"
+format="html">DITA 1.3 label</xref> in the GitHub issues tracker.</note>
     </section>
   </conbody>
 
   <related-links>
     <link format="html"
-      href="http://docs.oasis-open.org/dita/dita/v1.3/os/part3-all-inclusive/dita-v1.3-os-part3-all-inclusive.html"
-      scope="external">
-      <linktext>DITA Version 1.3 Part 3: All-Inclusive Edition (HTML)</linktext>
-    </link>
+href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.html "
+scope="external">
+<linktext>DITA Version 1.3 Part 3 (latest errata version): All-Inclusive Edition (HTML)</linktext>
+</link>
     <link format="pdf"
-      href="http://docs.oasis-open.org/dita/dita/v1.3/os/part3-all-inclusive/dita-v1.3-os-part3-all-inclusive.pdf"
-      scope="external">
-      <linktext>DITA Version 1.3 Part 3: All-Inclusive Edition (PDF)</linktext>
-    </link>
-    <link format="zip" href="http://docs.oasis-open.org/dita/dita/v1.3/os/dita-v1.3-os.zip" scope="external">
-      <linktext>DITA Version 1.3 (Distribution ZIP of the DITA source)</linktext>
-    </link>
+href="http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part3-all-inclusive.pdf" scope="external">
+<linktext>DITA Version 1.3 Part 3 (latest errata version): All-Inclusive Edition (PDF)</linktext>
+</link>
+    <link format="zip"
+href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/dita-v1.3-errata01-os-part3-all-inclusive-complete-dita.zip"
+scope="external">
+<linktext>DITA Version 1.3 Errata 01 (Distribution ZIP of the DITA source)</linktext>
+</link>
     <link format="html" href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita-adoption"
       scope="external">
       <linktext>DITA Adoption Technical Committee</linktext>


### PR DESCRIPTION
The content in these topics is quite outdated, and gives no-longer-useful information such as what version of DITA-OT 1.x added specific features of DITA 1.2.

This pull request cleans up the two topics, adds a bit of new information, updates links from the base spec to errata 01, and moves all of the links to keys.

The TOC currently has DITA 1.2 before DITA 1.3, which feels like it's "in order" but I'd suggest flipping that order because 1.3 support is far more important / relevant than 1.2 support at this point. Haven't put that in this pull request though because I know those maps are heavily in flux.

Another long-term cleanup item -- I noticed some of the existing keys for the spec use names like `dita-ot-spec` but should really be `dita-spec` or `dita13-spec` (because it's the DITA spec, not the DITA-OT spec). But that's pretty trivial and I don't want to cause churn by changing at this point.