### PR TITLE
Fix syntax error in sample plugin.xml file

### DIFF
--- a/dev_ref/html-customization-plugin-bundle-css.dita
+++ b/dev_ref/html-customization-plugin-bundle-css.dita
@@ -49,7 +49,7 @@
 &lt;plugin id="com.example.html5.custom.css"&gt;
   <b>&lt;require plugin="org.dita.html5"/&gt;</b>
   <b>&lt;feature extension="dita.conductor.transtype.check" value="html5-custom-css"/&gt;</b>
-  &lt;feature extension="dita.conductor.target.relative" value="build.xml"/&gt;
+  &lt;feature extension="dita.conductor.target.relative" file="build.xml"/&gt;
 &lt;/plugin&gt;</codeblock>
           </fig>
           <note>This plug-in will extend the default HTML5 transformation, so the <xmlelement>require</xmlelement>


### PR DESCRIPTION
Changed "value" to "file" so the plugin integrates and prevents 'does not exist in the project "DOST"' error message.

Signed-off-by: Lief Erickson <lief.erickson@gmail.com>