### PR TITLE
Suggested detail for DOTJ054E

### DIFF
--- a/topics/DITA-messages-details.xml
+++ b/topics/DITA-messages-details.xml
@@ -331,6 +331,13 @@
           your topics use one of these extensions, or configure the toolkit to allow additional extensions.</stentry>
       </strow>
       <strow>
+        <stentry conref="DITA-messages.xml#msgs/DOTJ054E-extra" conaction="pushreplace">This message indicates that the
+          <xmlatt>href</xmlatt> value specified in <varname>%1</varname> does not use proper URI syntax. This may occur when
+          <xmlatt>href</xmlatt> includes characters that should be escaped (such as the space character, which should be
+          <codeph>%20</codeph> when in a URI). In strict processing mode this will cause a build failure;
+          in other processing modes the build will continue using the value in <varname>%2</varname>.</stentry>
+      </strow>
+      <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTJ068E-extra" conaction="pushreplace">A conref "mark" action has been
           used to mark a target element without a corresponding content reference target. This may occur when the order
           of the "mark" element and the pushed element is reversed.</stentry>


### PR DESCRIPTION
Had a customer run into a DOTJ054E message that looked roughly like this:
```
inputfile.dita:39:95: [DOTJ054E][ERROR] Unable to parse invalid href attribute value "mailto:Sample Example/Austin/IBM", using 'mailto:Sample%20Example/Austin/IBM'.
```

Seeing this in a terminal with other log info, he didn't catch the change to `%20` and was confused why a seemingly valid link marked with `scope="external"` generated a message. 

The correct fix of course is to change the source, but I noticed our doc doesn't really give any detail for this message, and I've nearly always seen it come up with unescaped space characters, so thought perhaps the doc should suggest that. (This isn't the first time I've had somebody complain about the message for exactly this reason.)