### PR TITLE
Convert deprecated attributes to elements

### DIFF
--- a/samples/hierarchy.ditamap
+++ b/samples/hierarchy.ditamap
@@ -6,7 +6,8 @@
      applicable licenses.-->
 <!-- (C) Copyright IBM Corporation 2001, 2005. All Rights Reserved.
  *-->
-<map title="Working in the garage">
+<map>
+<title>Working in the garage</title>
 <topicref href="tasks/garagetaskoverview.xml" type="concept">
   <topicref href="tasks/changingtheoil.xml" type="task"/>
   <topicref href="tasks/organizing.xml" type="task"/>

--- a/samples/sequence.ditamap
+++ b/samples/sequence.ditamap
@@ -6,7 +6,8 @@
      applicable licenses.-->
 <!-- (C) Copyright IBM Corporation 2001, 2005. All Rights Reserved.
  *-->
-<map title="Working in the garage">
+<map>
+<title>Working in the garage</title>
 <topicref href="tasks/changingtheoil.xml" type="task"></topicref>
 <topicref href="tasks/organizing.xml" type="task"></topicref>
 <topicref href="tasks/shovellingsnow.xml" type="task"></topicref>

--- a/samples/tasks/washingthecar.xml
+++ b/samples/tasks/washingthecar.xml
@@ -10,7 +10,6 @@
 <title>Washing the car</title>
 <shortdesc>Keep your car looking great by washing it regularly.</shortdesc>
 <taskbody>
-<!--<context><p></p></context>-->
 <steps>
 <step><cmd>Move the car onto the driveway.</cmd>
 </step>
@@ -24,8 +23,8 @@ from the hose.</cmd></step>
 <step><cmd>Dry the car using a dampened chamois.</cmd>
 </step>
 </steps>
-<result><p><image href="../image/carwash.jpg" alt="washing the car" height="171"
-width="249"/></p></result>
+<result><p><image href="../image/carwash.jpg" height="171"
+width="249"><alt>washing the car</alt></image></p></result>
 </taskbody>
 <related-links>
 <link href="../concepts/waterhose.xml" format="dita" type="concept"></link>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I know these samples are not exactly stellar, and of limited utility. That said, last week I was looking ahead to DITA 2.0 where these deprecated attributes will be removed. So when I saw them a few minutes ago in our samples, it seemed we should go ahead and update them.