### PR TITLE
Minor edits to release info

### DIFF
--- a/release-notes/index.dita
+++ b/release-notes/index.dita
@@ -104,11 +104,12 @@
             <xref href="https://github.com/dita-ot/dita-ot/issues/2079" format="html" scope="external">#2079</xref>
           </li>
           <li id="2890">Ant scripts for DITA-OT builds now make use of <xmlatt>if:set</xmlatt> and
-              <xmlatt>unless:set</xmlatt> attributes in the Ant namespace, which can be used to control whether the item
-            is run or otherwise takes effect. These attributes replace custom implementations of <codeph>if</codeph> and
-              <codeph>unless</codeph> logic introduced before Ant had this capability.
-            <xref href="https://github.com/dita-ot/dita-ot/pull/2890" format="html" scope="external">#2890</xref>
-          </li>
+<xmlatt>unless:set</xmlatt> attributes in the Ant namespace, which can be used to control whether
+parameters are passed to XSLT modules. These attributes replace custom implementations of
+<codeph>if</codeph> and <codeph>unless</codeph> logic introduced before Ant had this capability.
+<xref href="https://github.com/dita-ot/dita-ot/pull/2890" format="html" scope="external"
+>#2890</xref>
+</li>
           <li id="2938">The PDF build code has been refactored and simplified to use the
               <xmlelement>xmlcatalog</xmlelement> element instead of using a custom <codeph>xml.catalog.files</codeph>
             property.

--- a/topics/migrating-to-3.1.dita
+++ b/topics/migrating-to-3.1.dita
@@ -9,8 +9,9 @@
     <navtitle>To 3.1</navtitle>
   </titlealts>
 
-  <shortdesc>DITA-OT 3.1 includes <ph id="summary">support for DITA 1.3 SVG domain elements, enhanced codeblock
-      processing, and incremental improvements to Lightweight DITA processing and PDF output</ph>.</shortdesc>
+  <shortdesc>DITA-OT 3.1 includes <ph id="summary">support for DITA 1.3 SVG domain elements,
+enhanced <xmlelement>codeblock</xmlelement> processing, and incremental improvements to Lightweight
+DITA processing and PDF output</ph>.</shortdesc>
 
   <refbody>
     <section>
@@ -22,19 +23,20 @@
 
     <section>
       <title>Custom if/unless attributes in Ant scripts</title>
-      <p>Ant scripts for DITA-OT builds now make use of <xmlatt>if:set</xmlatt> and <xmlatt>unless:set</xmlatt>
-        attributes in the Ant namespace, which can be used to control whether the item is run or otherwise takes effect.
-        These attributes replace custom implementations of <codeph>if</codeph> and <codeph>unless</codeph> logic
-        introduced before Ant had this capability.</p>
-      <p>If your plug-ins include Ant scripts that use the earlier custom implementations, add the following namespace
-        attributes to the root project:
-        <ul>
-          <li><xmlnsname>xmlns:if</xmlnsname>=<codeph>"ant:if"</codeph></li>
-          <li><xmlnsname>xmlns:unless</xmlnsname>=<codeph>"ant:unless"</codeph></li>
-        </ul></p>
-      <p>In custom Ant build files and in any files that supply parameters to existing Ant build files, replace all
-        occurrences of <codeph>if="property"</codeph> with <codeph>if<b>:set</b>="property"</codeph> (and
-          <codeph>unless</codeph> → <codeph>unless<b>:set</b></codeph> respectively).</p>
+      <p>Ant scripts for DITA-OT builds now make use of <xmlatt>if:set</xmlatt> and
+<xmlatt>unless:set</xmlatt> attributes in the Ant namespace, which can be used to control whether
+parameters are passed to XSLT modules. These attributes replace custom implementations of
+<codeph>if</codeph> and <codeph>unless</codeph> logic introduced before Ant had this capability.</p>
+      <p>If your plug-ins include Ant scripts that use <xmlatt>if</xmlatt> or
+<xmlatt>unless</xmlatt> on <xmlelement>param</xmlelement> elements that pass XSLT parameters, add
+the following namespace attributes to the root project: <ul>
+<li><xmlnsname>xmlns:if</xmlnsname>=<codeph>"ant:if"</codeph></li>
+<li><xmlnsname>xmlns:unless</xmlnsname>=<codeph>"ant:unless"</codeph></li>
+</ul></p>
+      <p>In custom Ant build files and in any files that supply parameters to existing DITA-OT XSLT
+modules, replace all occurrences of <codeph>if="property"</codeph> on <xmlelement>param</xmlelement>
+elements with <codeph>if<b>:set</b>="property"</codeph> (and <codeph>unless</codeph> →
+<codeph>unless<b>:set</b></codeph> respectively).</p>
       <p><codeblock outputclass="normalize-space show-line-numbers show-whitespace">&lt;root xmlns:if="ant:if" xmlns:unless="ant:unless">
   &lt;param name="antProperty" expression="${antProperty}"
          if<b>:set</b>="antProperty"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Minor edits to use or reject for the 3.1 release info.

Changes add `<xmlelement>` around one instance of "codeblock" and provide more specifics about the changes to use `if:set` and `unless:set`.