### PR TITLE
Fix / enhance topic for all extension points

### DIFF
--- a/resources/extension-points.xsl
+++ b/resources/extension-points.xsl
@@ -123,7 +123,11 @@
         </parmname>
       </dt>
       <!-- Changing the keyref to "extension-points-in-{$containing-plugin}/{@id}" would link to the exact parameter. -->
-      <dd>Defined in plug-in <keyword keyref="extension-points-in-{$containing-plugin}"><xsl:value-of select="$containing-plugin"/></keyword></dd>
+      <dd>Defined in plug-in
+        <xref keyref="extension-points-in-{$containing-plugin}">
+          <codeph><xsl:value-of select="$containing-plugin"/></codeph>
+        </xref>
+      </dd>
       <dd conkeyref="extension-points-in-{$containing-plugin}/{@id}.desc" id="{@id}.desc"/>
     </dlentry>
   </xsl:template>

--- a/resources/extension-points.xsl
+++ b/resources/extension-points.xsl
@@ -107,7 +107,7 @@
       </dd>
     </dlentry>
   </xsl:template>
-  
+
   <xsl:template match="extension-point" mode="reuse">
     <xsl:variable name="containing-plugin" select="ancestor::plugin/@id"/>
     <dlentry id="{@id}">
@@ -126,7 +126,7 @@
       <dd>Defined in plug-in
         <xref keyref="extension-points-in-{$containing-plugin}">
           <codeph><xsl:value-of select="$containing-plugin"/></codeph>
-        </xref>
+        </xref>.
       </dd>
       <dd conkeyref="extension-points-in-{$containing-plugin}/{@id}.desc" id="{@id}.desc"/>
     </dlentry>

--- a/resources/extension-points.xsl
+++ b/resources/extension-points.xsl
@@ -29,7 +29,7 @@
         <refbody>
           <section>
             <dl>
-              <xsl:apply-templates select="//extension-point">
+              <xsl:apply-templates select="//extension-point" mode="reuse">
                 <xsl:sort select="@name"/>
               </xsl:apply-templates>
             </dl>
@@ -105,6 +105,26 @@
       <dd id="{@id}.desc">
         <xsl:value-of select="@name"/>
       </dd>
+    </dlentry>
+  </xsl:template>
+  
+  <xsl:template match="extension-point" mode="reuse">
+    <xsl:variable name="containing-plugin" select="ancestor::plugin/@id"/>
+    <dlentry id="{@id}">
+      <xsl:if test="@deprecated = 'true'">
+        <xsl:attribute name="importance">deprecated</xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@required = 'true'">
+        <xsl:attribute name="importance">required</xsl:attribute>
+      </xsl:if>
+      <dt>
+        <parmname>
+          <xsl:value-of select="@id"/>
+        </parmname>
+      </dt>
+      <!-- Changing the keyref to "extension-points-in-{$containing-plugin}/{@id}" would link to the exact parameter. -->
+      <dd>Defined in plug-in <keyword keyref="extension-points-in-{$containing-plugin}"><xsl:value-of select="$containing-plugin"/></keyword></dd>
+      <dd conkeyref="extension-points-in-{$containing-plugin}/{@id}.desc" id="{@id}.desc"/>
     </dlentry>
   </xsl:template>
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Noticed that we have a problem in the docs today, now that we generate a summary topic with [ALL DITA-OT extension points](https://www.dita-ot.org/dev/extension-points/all-extension-points.html):

- We generate a topic for each plug-in with extension points. This defines the extension point `dita.conductor.target`.
- That target is obsolete; it's in our manually authored topic about [general extension points](https://www.dita-ot.org/dev/extension-points/plugin-extension-points-general.html), but with a note saying it's obsolete / deprecated. This note is pushed into the generated topic.
- We now *also* generate a summary topic with [ALL DITA-OT extension points](https://www.dita-ot.org/dev/extension-points/all-extension-points.html). This is where I end up first when looking through the TOC. The extension point `dita.conductor.target` is the very first one -- but without the note to let me know it's obsolete.
- This is a problem - but makes sense because we can't use conref push to push the updated description into **both** generated instances.

The fix here updates the way we generate the "all extension points" topic. It relies on the processing order where "conref push" is evaluated before conref:

- Instead of generating a second copy of the definition, we generate a conref to the topic for that plugin.
- If conref push is used to annotate the original generated definition (as with `dita.conductor.target` and several others), that is processed first
- The `@conref` attributes inside the "all extension points" topic are evaluated next, pulling in the annotated definitions
- Result: annotations to extension points show up in all cases.

There is an additional enhancement to go along with this now; in the "all extension points" topic, every extension point also states what plug-in it comes from (as a link to that topic). The links use a key, so that any plugin that does *not* add its extension points to the map will not appear as a link.