### PR TITLE
Amend exec command to fail on error

### DIFF
--- a/samples/ant_sample/dita-cmd.xml
+++ b/samples/ant_sample/dita-cmd.xml
@@ -14,8 +14,19 @@
     <attribute name="format"/>
     <attribute name="propertyfile"/>
     <sequential>
-      <exec executable="${dita.dir}/bin/dita">
-        <arg line="--input=@{input} --format=@{format} --propertyfile=@{propertyfile}"/>
+      <!-- For Unix run the DITA executable-->
+      <exec taskname="dita-cmd" executable="${dita.dir}/bin/dita" osfamily="unix" failonerror="true">
+        <arg value="--input"/>
+        <arg value="@{input}"/>
+        <arg value="--format"/>
+        <arg value="@{format}"/>
+        <arg value="--propertyfile"/>
+        <arg value="@{propertyfile}"/>
+      </exec>
+      <!-- For Windows run DITA from a DOS command -->
+      <exec taskname="dita-cmd" dir="${dita.dir}/bin" executable="cmd" osfamily="windows" failonerror="true">
+        <arg value="/C"/>
+        <arg value="dita --input @{input} --format @{format} --propertyfile=@{propertyfile}"/>
       </exec>
     </sequential>
   </macrodef>

--- a/topics/migrating-ant-to-dita.dita
+++ b/topics/migrating-ant-to-dita.dita
@@ -68,7 +68,7 @@
       <p>This example uses a <xmlelement>dita-cmd</xmlelement> Ant macro defined in the <filepath
           conref="../resources/conref-task.dita#ID/samples-dir"/><filepath>/ant_sample/dita-cmd.xml</filepath> file:</p>
       <p>
-        <codeblock outputclass="normalize-space show-line-numbers show-whitespace"><coderef href="../samples/ant_sample/dita-cmd.xml#line=11,21"/></codeblock></p>
+        <codeblock outputclass="normalize-space show-line-numbers show-whitespace"><coderef href="../samples/ant_sample/dita-cmd.xml#line=11,32"/></codeblock></p>
       <p>You can use this macro in your Ant build to call the <cmdname>dita</cmdname> command and pass the
           <parmname>input</parmname>, <parmname>format</parmname> and <parmname>propertyfile</parmname> parameters as
         follows:


### PR DESCRIPTION
This PR updates the existing `<dita-cmd>` macro to do the following:

* Work on both Windows and Linux machines
* Fail on error to avoid `build failed/build successful errors` - see https://groups.google.com/forum/#!topic/dita-ot-users/eVpktG7oluQ as an example
* Use `--` format for parameters
* User `arg value` parameters - related #250
* Added `taskname="dita-cmd"` to ensure that you can see that `dita-cmd` is failing when an error occurs.

Signed-off-by: Jason Fox <jason.fox@fiware.org>