### PR TITLE
Add 'language-xml' to @outputclass

### DIFF
--- a/reference/extended-functionality.dita
+++ b/reference/extended-functionality.dita
@@ -42,7 +42,7 @@
         last line of the file.</p>
     </section>
     <example>
-      <codeblock>&lt;coderef href="Parser.scala#line-range(5, 10)" format="scala"/></codeblock>
+      <codeblock outputclass="language-xml">&lt;coderef href="Parser.scala#line-range(5, 10)" format="scala"/></codeblock>
       <p>Only lines from 5 to 10 will be included in the output.</p>
     </example>
     <section>
@@ -57,7 +57,7 @@
       <p>The position line number starts from 0.</p>
     </section>
     <example>
-      <codeblock>&lt;coderef href="Parser.scala#line=4,10" format="scala"/></codeblock>
+      <codeblock outputclass="language-xml">&lt;coderef href="Parser.scala#line=4,10" format="scala"/></codeblock>
       <p>Only lines from 5 to 10 will be included in the output.</p>
     </example>
     <section>
@@ -94,7 +94,7 @@
           Given an XML snippet in a codeblock with lines that all begin with spaces (indicated here as dots “·”),</p>
       </section>
       <example>
-        <p><codeblock>··&lt;subjectdef keys="audience">
+        <p><codeblock outputclass="language-xml">··&lt;subjectdef keys="audience">
 ····&lt;subjectdef keys="novice"/>
 ····&lt;subjectdef keys="expert"/>
 ··&lt;/subjectdef></codeblock></p>
@@ -104,7 +104,7 @@
         <p>In this case, two spaces (“··”) would be removed from the beginning of each line, shifting content to the
           left by two characters, while preserving the indentation of lines that contain additional whitespace (beyond
           the common indent):</p>
-        <p><codeblock>&lt;subjectdef keys="audience">
+        <p><codeblock outputclass="language-xml">&lt;subjectdef keys="audience">
 ··&lt;subjectdef keys="novice"/>
 ··&lt;subjectdef keys="expert"/>
 &lt;/subjectdef></codeblock></p>

--- a/reference/flagging-migration.dita
+++ b/reference/flagging-migration.dita
@@ -104,7 +104,7 @@
           <codeph>"commonattributes"</codeph>, DITAVAL style will be processed when needed. Because virtually every
         element includes a call to this common template, there is little chance that your override needs to explicitly
         process the style. The new line in <codeph>"commonattributes"</codeph> that handles the style is:
-        <codeblock>&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/></codeblock></p></section>
+        <codeblock outputclass="language-xml">&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/></codeblock></p></section>
     <section>
       <title>Migrating <codeph>"start-flagit"</codeph>, <codeph>"start-revflag"</codeph>, <codeph>"end-flagit"</codeph>,
         and <codeph>"end-flagit"</codeph> named templates</title>
@@ -123,10 +123,10 @@
       <ul>
         <li>
           <p>Create starting flag and revision images:</p>
-          <codeblock>&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/></codeblock></li>
+          <codeblock outputclass="language-xml">&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/></codeblock></li>
         <li>
           <p>Create ending flag and revision images:</p>
-          <codeblock>&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/></codeblock></li>
+          <codeblock outputclass="language-xml">&lt;xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/></codeblock></li>
       </ul>
       <p>For example, the following lines are used in DITA-OT 1.7 to process the <xmlelement>ul</xmlelement> element
         (replacing the 29 lines used in DITA-OT

--- a/reference/preprocess-flagging.dita
+++ b/reference/preprocess-flagging.dita
@@ -23,7 +23,7 @@
           <pd>
             <p>When any flag is active on an element, a <xmlelement>ditaval-startprop</xmlelement> element will be
               created as the first child of the flagged element:</p>
-            <codeblock>&lt;ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop "></codeblock>
+            <codeblock outputclass="language-xml">&lt;ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop "></codeblock>
             <p>The <xmlelement>ditaval-startprop</xmlelement> element will contain the following:
               <ul>
                 <li>If the active flags should create a new style, that style is included using standard CSS markup on
@@ -44,7 +44,7 @@
           <pd>
             <p>When any flag is active on an element, a <xmlelement>ditaval-endprop</xmlelement> element will be created
               as the last child of the flagged element:</p>
-            <codeblock>&lt;ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop "></codeblock>
+            <codeblock outputclass="language-xml">&lt;ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop "></codeblock>
             <p>CSS values and <xmlelement>style-conflict</xmlelement> elements are not included on this element.</p>
             <p>Any <xmlelement>prop</xmlelement> or <xmlelement>revprop</xmlelement> elements that define active flags
               will be copied in as children of <xmlelement>ditaval-prop</xmlelement>. Any
@@ -111,7 +111,7 @@
       <p>Now assume the following paragraph exists in a topic. Class attributes are included, as they would normally be
         in the middle of the preprocess routine; <xmlatt>xtrf</xmlatt> and <xmlatt>xtrc</xmlatt> are left off for
         clarity.</p>
-      <codeblock>&lt;p audience="user">Simple user; includes style but no images&lt;/p></codeblock>
+      <codeblock outputclass="language-xml">&lt;p audience="user">Simple user; includes style but no images&lt;/p></codeblock>
       <p>Based on the DITAVAL above, audience="user" results in a style with underlining and with a green background.
         The interpreted CSS value is added to <xmlatt>outputclass</xmlatt> on
         <xmlelement>ditaval-startprop</xmlelement>, and the actual property definition is included at the start and end
@@ -139,7 +139,7 @@
       <p>This example includes a paragraph with conflicting styles. When the audience and platform attributes are both
         evaluated, the DITAVAL indicates that the background color is both green and blue. In this situation, the
           <xmlelement>style-conflict</xmlelement> element is evaluated to determine how to style the content.</p>
-      <codeblock>&lt;p audience="user" platform="win">Conflicting styles (still no images)&lt;/p></codeblock>
+      <codeblock outputclass="language-xml">&lt;p audience="user" platform="win">Conflicting styles (still no images)&lt;/p></codeblock>
       <p>The <xmlelement>style-conflict</xmlelement> element results in a background color of red, so this value is
         added to <xmlatt>outputclass</xmlatt> on <xmlelement>ditaval-startprop</xmlelement>. As above, active properties
         are copied into the generated elements; the <xmlelement>style-conflict</xmlelement> element itself is also

--- a/reference/preprocess-mapref.dita
+++ b/reference/preprocess-mapref.dita
@@ -9,7 +9,7 @@
   <conbody>
     <section>
       <p>Maps reference other maps by using the following sorts of markup:
-        <codeblock>&lt;topicref href="other.ditamap" format="ditamap"/>
+        <codeblock outputclass="language-xml">&lt;topicref href="other.ditamap" format="ditamap"/>
 ...
 &lt;mapref href="other.ditamap"/></codeblock></p>
       <p>As a result of the mapref step, the element that references another map is replaced by the topic references

--- a/reference/processing-order.dita
+++ b/reference/processing-order.dita
@@ -13,7 +13,7 @@
       <p>The DITA-OT project has found that filtering first provides several benefits. Consider the following sample
         that contains a <xmlelement>note</xmlelement> element that both uses conref and contains a
           <xmlatt>product</xmlatt>
-        attribute:<codeblock>&lt;note conref="documentA.dita#doc/note" product="MyProd"/></codeblock></p>
+        attribute:<codeblock outputclass="language-xml">&lt;note conref="documentA.dita#doc/note" product="MyProd"/></codeblock></p>
       <p>If the <xmlatt>conref</xmlatt> attribute is evaluated first, then documentA must be parsed in order to retrieve
         the note content. That content is then stored in the current document (or in a representation of that document
         in memory). However, if all content with product="MyProd" is filtered out, then that work is all discarded later
@@ -33,7 +33,7 @@
         will differ. For example, in the code sample above, the <xmlatt>product</xmlatt> attribute on the reference
         target will override the product setting on the referencing note. Assume that the referenced
           <xmlelement>note</xmlelement> element in documentA is defined as follows:
-        <codeblock>&lt;note id="note" product="SomeOtherProduct">This is an important note!&lt;/note></codeblock></p>
+        <codeblock outputclass="language-xml">&lt;note id="note" product="SomeOtherProduct">This is an important note!&lt;/note></codeblock></p>
       <p>A process that filters out product="SomeOtherProduct" will remove the target of the original conref before that
         conref is ever evaluated, which will result in a broken reference. Evaluating conref first would resolve the
         reference, and only later filter out the target of the conref. While some use cases can be found where this is

--- a/topics/implement-saxon-collation-uri-resolvers.dita
+++ b/topics/implement-saxon-collation-uri-resolvers.dita
@@ -66,7 +66,7 @@
             <codeph>org.dita.dost.module.saxon.DelegatingCollationUriResolver</codeph>:<codeblock>org.example.i18n.saxon.MyCollationUriResolver</codeblock>
           <p>You can create the services file using <xmlelement>service</xmlelement> elements in an Ant
             <xmlelement>jar</xmlelement>
-            task:<codeblock>&lt;jar destfile="${basedir}/target/lib/example-saxon.jar">
+            task:<codeblock outputclass="language-xml">&lt;jar destfile="${basedir}/target/lib/example-saxon.jar">
   ⋮
   &lt;service type="org.dita.dost.module.saxon.DelegatingCollationUriResolver">
     &lt;provider classname="org.example.i18n.saxon.MyCollationUriResolver"/>
@@ -75,7 +75,7 @@
 &lt;/jar></codeblock></p></li>
         <li>To use the collator in XSLT style sheets, specify the collation URI on <xmlatt>xsl:sort</xmlatt> elements (or
           anywhere a collator URI can be
-          specified):<codeblock>&lt;xsl:apply-templates select="word">
+          specified):<codeblock outputclass="language-xml">&lt;xsl:apply-templates select="word">
   &lt;xsl:sort collation="http://org.example.i18n.MyCollator"/>
 &lt;/xsl:apply-templates></codeblock></li>
       </ol></p>

--- a/topics/implement-saxon-customizations.dita
+++ b/topics/implement-saxon-customizations.dita
@@ -21,7 +21,7 @@
     <p>These extensions use the DITA Open Toolkit Ant <xmlelement>pipeline</xmlelement> element to wrap
         <xmlelement>xslt</xmlelement> elements. You can do this in plug-ins as shown in this excerpt from the DITA
       Community I18N plugin’s <filepath>build.xml</filepath>
-      file:<codeblock>&lt;target name="org.dita-community.i18n-saxon-extension-test">
+      file:<codeblock outputclass="language-xml">&lt;target name="org.dita-community.i18n-saxon-extension-test">
   &lt;pipeline message="Test the DITA Community i18n Saxon extension functions"
             taskname="i18n-extension-function-test">
     &lt;xslt

--- a/topics/implement-saxon-extension-functions.dita
+++ b/topics/implement-saxon-extension-functions.dita
@@ -27,7 +27,7 @@
 com.example.saxon.functions.Substract</codeblock>
           <p>You can create the file using <xmlelement>service</xmlelement> elements in an Ant
               <xmlelement>jar</xmlelement>
-            task:<codeblock>&lt;jar destfile="${basedir}/target/lib/example-saxon.jar">
+            task:<codeblock outputclass="language-xml">&lt;jar destfile="${basedir}/target/lib/example-saxon.jar">
   ⋮
   &lt;service type="net.sf.saxon.lib.ExtensionFunctionDefinition">
     &lt;provider classname="com.example.saxon.functions.Add"/>
@@ -36,12 +36,12 @@ com.example.saxon.functions.Substract</codeblock>
   ⋮
 &lt;/jar></codeblock></p></li>
         <li>In your XSLT transformations, declare the namespace the functions are bound
-          to:<codeblock>&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          to:<codeblock outputclass="language-xml">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 <b>xmlns:eg="http://example.com/saxon-extensions"</b>
                 version="2.0"></codeblock></li>
       </ol></p>
     <p>You should then be able to use the extension functions as you would any other
-      function:<codeblock>&lt;xsl:variable name="test" select="<b>eg:add(1, 2)</b>"/></codeblock></p>
+      function:<codeblock outputclass="language-xml">&lt;xsl:variable name="test" select="<b>eg:add(1, 2)</b>"/></codeblock></p>
   </body>
 </topic>

--- a/topics/migrating-to-1.5.4.dita
+++ b/topics/migrating-to-1.5.4.dita
@@ -93,7 +93,7 @@
       <title>Plugin URI scheme</title>
       <p>Support for the <keyword>plugin</keyword> URI scheme has been added to XSLT stylesheets. Plug-ins can refer to
         files in other plug-ins without hard-coding relative paths, for example: </p>
-      <codeblock xml:space="preserve">&lt;xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo_1.0.xsl"/&gt;</codeblock>
+      <codeblock outputclass="language-xml" xml:space="preserve">&lt;xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo_1.0.xsl"/&gt;</codeblock>
     </section>
     <section>
       <title>XHTML</title>

--- a/topics/migrating-to-3.3.dita
+++ b/topics/migrating-to-3.3.dita
@@ -42,9 +42,9 @@
         <p>In XSLT, use the <codeph>plugin</codeph> URI scheme in <xmlelement>xsl:import</xmlelement> and
             <xmlelement>xsl:include</xmlelement> to reference files in other plug-ins.</p>
         <p>Instead of:</p>
-        <p><codeblock>&lt;xsl:import href="../../org.dita.base/xsl/common/output-message.xsl"/></codeblock></p>
+        <p><codeblock outputclass="language-xml">&lt;xsl:import href="../../org.dita.base/xsl/common/output-message.xsl"/></codeblock></p>
         <p>use:</p>
-        <p><codeblock>&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock></p>
+        <p><codeblock outputclass="language-xml">&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock></p>
         <p>As with the plug-in directory property in Ant, this allows plug-ins to resolve to the correct directory even
           when a plug-in moves to a new location. The plug-in is referenced using the syntax
               <codeph>plugin:<varname>plugin-id</varname>:<varname>path/within/plugin/file.xsl</varname></codeph>.</p>
@@ -63,7 +63,7 @@
           but this file may be removed in an upcoming release.</ph></p>
       <fig>
         <title>Legacy catalog placeholder content</title>
-        <codeblock>&lt;nextCatalog catalog="plugins/org.dita.base/catalog-dita.xml"/></codeblock>
+        <codeblock outputclass="language-xml">&lt;nextCatalog catalog="plugins/org.dita.base/catalog-dita.xml"/></codeblock>
       </fig>
     </section>
 

--- a/topics/pdf-plugin-structure.dita
+++ b/topics/pdf-plugin-structure.dita
@@ -57,9 +57,9 @@
       the changes in the publishing process, you find the corresponding entry for each file you modified in the
         <filepath>catalog.xml</filepath> file.</p>
     <p>It should look like this:</p>
-    <codeblock>&lt;!--uri name="cfg:fo/attrs/custom.xsl" uri="fo/attrs/custom.xsl"/--&gt;</codeblock>
+    <codeblock outputclass="language-xml">&lt;!--uri name="cfg:fo/attrs/custom.xsl" uri="fo/attrs/custom.xsl"/--&gt;</codeblock>
     <p>Remove the comment markers <codeph>!--</codeph> and <codeph>--</codeph> to enable the change:</p>
-    <codeblock>&lt;uri name="cfg:fo/attrs/custom.xsl" uri="fo/attrs/custom.xsl"/&gt;</codeblock>
+    <codeblock outputclass="language-xml">&lt;uri name="cfg:fo/attrs/custom.xsl" uri="fo/attrs/custom.xsl"/&gt;</codeblock>
     <p>Your customization should now be enabled as part of the publishing process.</p>
     <fig>
       <title>Sample custom plug-in structure</title>

--- a/topics/pdf2-creating-change-bars.dita
+++ b/topics/pdf2-creating-change-bars.dita
@@ -34,7 +34,7 @@
     </ul>
     <fig>
       <title>Sample revision bar configuration</title>
-      <codeblock outputclass="language-xml xml">&lt;revprop action="flag" changebar="solid" color="green"/></codeblock>
+      <codeblock outputclass="language-xml">&lt;revprop action="flag" changebar="solid" color="green"/></codeblock>
     </fig>
     <p>DITA-OT uses a default offset of 2 mm to place the revision bar near the edge of the text column. The offset,
       placement and width are not currently configurable via attribute values.</p>

--- a/topics/plugin-best-practices.dita
+++ b/topics/plugin-best-practices.dita
@@ -43,8 +43,8 @@
         <p>For example, instead of creating a template named <codeph>searchbar</codeph>, use something like
             <codeph>corp:searchbar</codeph> instead. This ensures that if future versions of DITA-OT add a
             <codeph>searchbar</codeph> template, your custom version will be unaffected.</p>
-        <p>Instead of: <codeblock>&lt;xsl:template name="searchbar"/></codeblock></p>
-        <p>use: <codeblock>&lt;xsl:template name="corp:searchbar"/></codeblock></p>
+        <p>Instead of: <codeblock outputclass="language-xml">&lt;xsl:template name="searchbar"/></codeblock></p>
+        <p>use: <codeblock outputclass="language-xml">&lt;xsl:template name="corp:searchbar"/></codeblock></p>
       </li>
     </ul>
   </conbody>

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -37,9 +37,9 @@
       <p>In Ant scripts, always refer to files in other plug-ins using the
             <codeph>dita.plugin.<varname>plugin-id</varname>.dir</codeph> property.</p>
       <p>Instead of:</p>
-      <p><codeblock>&lt;property name="base" location="../example/custom.xsl"/></codeblock></p>
+      <p><codeblock outputclass="language-xml">&lt;property name="base" location="../example/custom.xsl"/></codeblock></p>
       <p>use:</p>
-      <p><codeblock>&lt;property name="base" location="${dita.plugin.example.dir}/custom.xsl"/></codeblock></p>
+      <p><codeblock outputclass="language-xml">&lt;property name="base" location="${dita.plugin.example.dir}/custom.xsl"/></codeblock></p>
       <p>This fixes cases where plug-ins are installed to custom plug-in directories or the plug-in folder name doesn’t
         match the plug-in ID.</p>
     </section>
@@ -98,9 +98,9 @@
       <p>In XSLT, use the <codeph>plugin</codeph> URI scheme in <xmlelement>xsl:import</xmlelement> and
           <xmlelement>xsl:include</xmlelement> to reference files in other plug-ins.</p>
       <p>Instead of:</p>
-      <p><codeblock>&lt;xsl:import href="../../org.dita.base/xsl/common/output-message.xsl"/></codeblock></p>
+      <p><codeblock outputclass="language-xml">&lt;xsl:import href="../../org.dita.base/xsl/common/output-message.xsl"/></codeblock></p>
       <p>use:</p>
-      <p><codeblock>&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock></p>
+      <p><codeblock outputclass="language-xml">&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock></p>
       <p>As with the plug-in directory property in Ant, this allows plug-ins to resolve to the correct directory even
         when a plug-in moves to a new location. The plug-in is referenced using the syntax
             <codeph>plugin:<varname>plugin-id</varname>:<varname>path/within/plugin/file.xsl</varname></codeph>.</p>

--- a/topics/using-plugin-URI-extension.dita
+++ b/topics/using-plugin-URI-extension.dita
@@ -42,7 +42,7 @@
         </info>
         <stepxmp>
           <p>The following example imports the base output-message.xsl processing:</p>
-          <codeblock>&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock>
+          <codeblock outputclass="language-xml">&lt;xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/></codeblock>
         </stepxmp>
         <info>
           <p>To use the URI extension, your plug-in must reference the DITA-OT catalog file. In your


### PR DESCRIPTION
## Description
Add `@outputclass="language-xml"` to `<codeblock>` where appropriate.

## Motivation and Context
dita-ot/website#216 adds new styling capabilities for site output. Some of this styling is dependent on `@outputclass`. This PR adds the `@outputclass` or the `language-xml` to additional source files.

## How Has This Been Tested?

Built website locally with gradle using dita-ot/website@fbbd745d. Build successfully showed XML elements and attributes with styling. 

Built website locally with gradle using dita-ot/website@91db9e3c. Build completed successfully, but no styling was present. This is expected.

Built PDF locally and styling was as expected (i.e., no colors).

## Type of Changes

- New feature _(non-breaking change which adds functionality)_
