### PR TITLE
Enable PDF index

### DIFF
--- a/DITA-OT_docs.xpr
+++ b/DITA-OT_docs.xpr
@@ -72,6 +72,14 @@
                                     <Integer>0</Integer>
                                 </field>
                             </breakLineElement>
+                            <breakLineElement>
+                                <field name="elementExpression">
+                                    <String>indexterm</String>
+                                </field>
+                                <field name="breakPolicy">
+                                    <Integer>1</Integer>
+                                </field>
+                            </breakLineElement>
                         </breakLineElement-array>
                     </entry>
                     <entry>

--- a/DITA-OT_docs.xpr
+++ b/DITA-OT_docs.xpr
@@ -80,6 +80,22 @@
                                     <Integer>1</Integer>
                                 </field>
                             </breakLineElement>
+                            <breakLineElement>
+                                <field name="elementExpression">
+                                    <String>index-see</String>
+                                </field>
+                                <field name="breakPolicy">
+                                    <Integer>1</Integer>
+                                </field>
+                            </breakLineElement>
+                            <breakLineElement>
+                                <field name="elementExpression">
+                                    <String>index-see-also</String>
+                                </field>
+                                <field name="breakPolicy">
+                                    <Integer>1</Integer>
+                                </field>
+                            </breakLineElement>
                         </breakLineElement-array>
                     </entry>
                     <entry>

--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -31,12 +31,16 @@
                 <parmname>DRAFT</parmname> in most XSLT modules.<note type="tip">For PDF output, setting the
                   <parmname>args.draft</parmname> parameter to <option>yes</option> causes the contents of the
                   <xmlelement>titlealts</xmlelement> element to be rendered below the title.
-                  <indexterm><xmlelement>titlealts</xmlelement></indexterm>
-                  <indexterm start="ant-xslt-params">XSLT</indexterm>
-                  <indexterm>draft<indexterm>args.draft</indexterm><indexterm>PDF</indexterm></indexterm>
-                  <indexterm>PDF<indexterm>draft</indexterm></indexterm>
-                  <indexterm>parameters<indexterm>args.draft</indexterm></indexterm>
-                </note>
+                <indexterm><xmlelement>titlealts</xmlelement></indexterm>
+                <indexterm start="ant-xslt-params">XSLT</indexterm>
+                <indexterm>draft
+                  <indexterm>args.draft</indexterm>
+                  <indexterm>PDF</indexterm></indexterm>
+                <indexterm>PDF
+                  <indexterm>draft</indexterm></indexterm>
+                <indexterm>parameters
+                  <indexterm>args.draft</indexterm></indexterm>
+              </note>
             </pd>
           </plentry>
           <plentry id="args.figurelink.style">
@@ -65,13 +69,18 @@
                 <p>DITAVAL files are evaluated in the order specified, so conditions specified in the first file take
                   precedence over matching conditions specified in later files, just as conditions at the start of a
                   DITAVAL document take precedence over matching conditions later in the same document.</p>
-                <indexterm>DITAVAL<indexterm><parmname>args.filter</parmname></indexterm></indexterm>
-                <indexterm>DITAVAL<index-see-also>filters</index-see-also></indexterm> <!-- https://github.com/dita-ot/dita-ot/issues/3319 -->
+                <indexterm>DITAVAL
+                  <indexterm><parmname>args.filter</parmname></indexterm></indexterm>
+                <!-- https://github.com/dita-ot/dita-ot/issues/3319 -->
+                <indexterm>DITAVAL<index-see-also>filters</index-see-also></indexterm>
                 <indexterm>DITAVAL<index-see-also>profiling</index-see-also></indexterm>
                 <indexterm>OS X<index-see>macOS</index-see></indexterm>
-                <indexterm>macOS<indexterm>delimiter</indexterm></indexterm>
-                <indexterm>Linux<indexterm>delimiter</indexterm></indexterm>
-                <indexterm>Windows<indexterm>delimiter</indexterm></indexterm>
+                <indexterm>macOS
+                  <indexterm>delimiter</indexterm></indexterm>
+                <indexterm>Linux
+                  <indexterm>delimiter</indexterm></indexterm>
+                <indexterm>Windows
+                  <indexterm>delimiter</indexterm></indexterm>
               </note>
             </pd>
           </plentry>
@@ -93,7 +102,7 @@
               <note>This option dramatically speeds up processing time. However, there is a known problem with using
                 this feature for documents that use XML entities. If your build fails with parser errors about entity
                 resolution, set this parameter to <option>no</option>.
-              <indexterm>processing time</indexterm></note>
+                <indexterm>processing time</indexterm></note>
             </pd>
           </plentry>
           <plentry id="args.input">
@@ -132,8 +141,12 @@
               <p>For PDF output, the default value is <option>nofamily</option>. For all other formats, the default
                 value is <option>all</option>.
                 <indexterm>args.rellinks</indexterm>
-                <indexterm>PDF<indexterm>related links</indexterm><indexterm>args.rellinks</indexterm></indexterm>
-                <indexterm>HTML5<indexterm>related links</indexterm><indexterm>args.rellinks</indexterm></indexterm>
+                <indexterm>PDF
+                  <indexterm>related links</indexterm>
+                  <indexterm>args.rellinks</indexterm></indexterm>
+                <indexterm>HTML5
+                  <indexterm>related links</indexterm>
+                  <indexterm>args.rellinks</indexterm></indexterm>
               </p></pd>
           </plentry>
           <plentry id="args.tablelink.style">
@@ -146,8 +159,9 @@
                 the XSLT parameter <parmname>TABLELINK</parmname>.</ph><note rev="2.0">Support for PDF was added in
                 DITA-OT 2.0. By default PDF uses the value <option>NUMTITLE</option>, which is not supported for other
                 transformation types; this results in "Table 5. Title".
-                <indexterm>tables<indexterm>args.tablelink.style</indexterm></indexterm>
-                </note></pd>
+                <indexterm>tables
+                  <indexterm>args.tablelink.style</indexterm></indexterm>
+              </note></pd>
           </plentry>
           <plentry id="cleantemp">
             <pt>
@@ -167,7 +181,8 @@
                 Identifying Languages</xref>.
               <indexterm><xmlatt>xml:lang</xmlatt></indexterm>
               <indexterm>IETF BCP 47</indexterm>
-              <indexterm>languages<indexterm>default</indexterm></indexterm>
+              <indexterm>languages
+                <indexterm>default</indexterm></indexterm>
             </pd>
           </plentry>
           <plentry id="dita.temp.dir">
@@ -215,15 +230,17 @@
               <note>Disabling debugging attributes reduces the size of temporary files and thus reduces memory
                 consumption. However, the log messages no longer have the source information available and thus the
                 ability to debug problems might deteriorate.
-              <indexterm>debugging<indexterm>generate-debug-attributes</indexterm></indexterm>
-              <indexterm>memory</indexterm>
+                <indexterm>debugging
+                  <indexterm>generate-debug-attributes</indexterm></indexterm>
+                <indexterm>memory</indexterm>
               </note>
             </pd>
           </plentry>
           <plentry id="generate.copy.outer">
             <pt>
               <parmname>generate.copy.outer</parmname>
-              <ph><indexterm><parmname>generate.copy.outer</parmname></indexterm></ph>
+              <ph>
+                <indexterm><parmname>generate.copy.outer</parmname></indexterm></ph>
             </pt>
             <pd conaction="mark" conref="parameters-base.dita#base/generate.copy.outer.desc"/>
             <pd conaction="pushafter">
@@ -247,7 +264,7 @@
               <note type="warning" platform="windows">Microsoft HTML Help Compiler cannot produce HTML Help for
                 documentation projects that use outer content. The content files must reside in or below the directory
                 containing the master DITA map file, and the map file cannot specify ".." at the start of the
-                <xmlatt>href</xmlatt> attributes for <xmlelement>topicref</xmlelement> elements.
+                  <xmlatt>href</xmlatt> attributes for <xmlelement>topicref</xmlelement> elements.
                 <indexterm><xmlelement>topicref</xmlelement></indexterm>
                 <indexterm><xmlatt>href</xmlatt></indexterm>
               </note>
@@ -269,7 +286,8 @@
             <pd conaction="pushafter">Acceptable values include any value normally allowed on the <xmlatt>chunk</xmlatt>
               attribute. If the map does not have a <xmlatt>chunk</xmlatt> attribute, this value will be used; if the
               map already has a <xmlatt>chunk</xmlatt> attribute specified, this value will be used instead.
-              <indexterm><xmlatt>chunk</xmlatt><indexterm><parmname>root-chunk-override</parmname></indexterm></indexterm>
+              <indexterm><xmlatt>chunk</xmlatt>
+                <indexterm><parmname>root-chunk-override</parmname></indexterm></indexterm>
             </pd>
           </plentry>
           <plentry id="transtype">
@@ -331,7 +349,8 @@
                   CSS files) will be copied to the root level of the output folder. To copy CSS files to an output
                   subfolder named <filepath>css</filepath>, set <parmname>args.csspath</parmname> to
                     <option>css</option>.
-                  <indexterm>CSS<indexterm>copy to specific location</indexterm></indexterm>
+                  <indexterm>CSS
+                    <indexterm>copy to specific location</indexterm></indexterm>
                 </note></div>
             </pd>
           </plentry>
@@ -373,9 +392,12 @@
                   practice is to place all content into a <xmlelement>div</xmlelement> element. In HTML5 output, the
                   footer file contents will be wrapped in an HTML5 <xmlelement>footer</xmlelement> element with the
                     <xmlatt>role</xmlatt> attribute set to <option>contentinfo</option>.
-                  <indexterm><xmlelement>div</xmlelement><indexterm>HTML footer</indexterm><indexterm><parmname>args.ftr</parmname></indexterm></indexterm>
+                  <indexterm><xmlelement>div</xmlelement>
+                    <indexterm>HTML footer</indexterm>
+                    <indexterm><parmname>args.ftr</parmname></indexterm></indexterm>
                   <indexterm><xmlatt>role</xmlatt></indexterm>
-                  <indexterm>HTML5<indexterm>footers</indexterm></indexterm>
+                  <indexterm>HTML5
+                    <indexterm>footers</indexterm></indexterm>
                 </note>
               </div></pd>
           </plentry>
@@ -400,7 +422,9 @@
                   If you need to insert more than one element into the HTML page head, wrap the content in a
                     <xmlelement>div</xmlelement> element. The division wrapper in the header file will be discarded when
                   generating HTML files, and the contents will be inserted into each page head.
-                  <indexterm><xmlelement>div</xmlelement><indexterm>HTML <xmlelement>head</xmlelement></indexterm><indexterm><parmname>args.hdf</parmname></indexterm></indexterm>
+                  <indexterm><xmlelement>div</xmlelement>
+                    <indexterm>HTML <xmlelement>head</xmlelement></indexterm>
+                    <indexterm><parmname>args.hdf</parmname></indexterm></indexterm>
                 </note></div></pd>
           </plentry>
           <plentry id="args.hdr">
@@ -415,17 +439,22 @@
                   practice is to place all content into a <xmlelement>div</xmlelement> element. In HTML5 output, the
                   contents of the header file will be wrapped in an HTML5 <xmlelement>header</xmlelement> element with
                   the <xmlatt>role</xmlatt> attribute set to <option>banner</option>.
-                  <indexterm><xmlelement>div</xmlelement><indexterm>HTML header</indexterm><indexterm><parmname>args.hdr</parmname></indexterm></indexterm>
+                  <indexterm><xmlelement>div</xmlelement>
+                    <indexterm>HTML header</indexterm>
+                    <indexterm><parmname>args.hdr</parmname></indexterm></indexterm>
                   <indexterm><xmlelement>header</xmlelement></indexterm>
                   <indexterm><xmlatt>role</xmlatt></indexterm>
-                  <indexterm>HTML5<indexterm>headers</indexterm></indexterm>
+                  <indexterm>HTML5
+                    <indexterm>headers</indexterm></indexterm>
                 </note>
               </div></pd>
           </plentry>
           <plentry id="args.hide.parent.link" importance="deprecated">
             <pt>
               <parmname>args.hide.parent.link</parmname>
-              <ph><indexterm>deprecated features<indexterm><parmname>args.hide.parent.link</parmname></indexterm></indexterm></ph>
+              <ph>
+                <indexterm>deprecated features
+                  <indexterm><parmname>args.hide.parent.link</parmname></indexterm></indexterm></ph>
             </pt>
             <pd conaction="mark" conref="parameters-base-html.dita#base-html/args.hide.parent.link.desc"/>
             <pd conaction="pushafter">
@@ -532,13 +561,16 @@
               is the symbolic name for the plugin in Eclipse. The default value is
                 <option>org.sample.help.doc</option>.<note type="tip">The toolkit ignores the value of this parameter
                 when it processes an Eclipse map.
-                <indexterm><xmlatt>id</xmlatt><indexterm><parmname>args.eclipse.symbolic.name</parmname></indexterm></indexterm>
-                </note><draft-comment author="Kristen James Eberlein"
-                time="11 August 2012">I'm not clear what this means. Is the default value for the
-                  <parmname>args.eclipse.symbolic.name</parmname> parameter the value of the <xmlatt>id</xmlatt>
-                attribute on the <xmlelement>map</xmlelement> or <xmlelement>plugin</xmlelement> element, if provided,
-                and the <option>org.sample.help.doc</option> if there is not a value for the <xmlatt>id</xmlatt>
-                attribute or the <parmname>args.eclipse.symbolic.name</parmname> parameter?</draft-comment></pd>
+                <indexterm><xmlatt>id</xmlatt>
+                  <indexterm><parmname>args.eclipse.symbolic.name</parmname></indexterm></indexterm>
+              </note>
+              <draft-comment author="Kristen James Eberlein" time="11 August 2012">I'm not clear what this means. Is the
+                default value for the <parmname>args.eclipse.symbolic.name</parmname> parameter the value of the
+                  <xmlatt>id</xmlatt> attribute on the <xmlelement>map</xmlelement> or <xmlelement>plugin</xmlelement>
+                element, if provided, and the <option>org.sample.help.doc</option> if there is not a value for the
+                  <xmlatt>id</xmlatt> attribute or the <parmname>args.eclipse.symbolic.name</parmname>
+                parameter?</draft-comment>
+            </pd>
           </plentry>
         </parml>
       </section>
@@ -578,10 +610,13 @@
               <p>Enables internationalization (I18N) font processing to provide per-character font selection for FO
                 renderers that do not support the <codeph>font-selection-strategy</codeph> property (such as Apache
                 FOP).
-                <indexterm>Apache FOP<indexterm>I18N</indexterm></indexterm>
+                <indexterm>Apache FOP
+                  <indexterm>I18N</indexterm></indexterm>
                 <indexterm>FOP<index-see>Apache FOP</index-see></indexterm>
-                <indexterm>I18N<indexterm><parmname>org.dita.pdf2.i18n.enabled</parmname></indexterm></indexterm>
-                <indexterm>fonts<indexterm>PDF</indexterm></indexterm>
+                <indexterm>I18N
+                  <indexterm><parmname>org.dita.pdf2.i18n.enabled</parmname></indexterm></indexterm>
+                <indexterm>fonts
+                  <indexterm>PDF</indexterm></indexterm>
               </p>
               <p>When this feature is enabled, DITA-OT uses a font mapping process that takes the content language into
                 consideration. The mapping process uses configuration files for each language to define characters that
@@ -604,7 +639,8 @@
             <pd conaction="mark" conref="parameters-pdf.dita#pdf/outputFile.base.desc"/>
             <pd conaction="pushafter">By default, the PDF file uses the base filename of the input
                 <filepath>.ditamap</filepath> file.
-            <indexterm>DITA maps<indexterm>PDF file name</indexterm></indexterm></pd>
+              <indexterm>DITA maps
+                <indexterm>PDF file name</indexterm></indexterm></pd>
           </plentry>
           <plentry id="pdf.formatter">
             <pt>
@@ -614,22 +650,26 @@
             <!-- Added to inject index entries into the right location. -->
             <pd conaction="mark" conref="parameters-pdf.dita#pdf/pdf.formatter.desc"/>
             <pd conaction="pushafter">
-              <indexterm>Apache FOP<indexterm><parmname>pdf.formatter</parmname></indexterm></indexterm>
+              <indexterm>Apache FOP
+                <indexterm><parmname>pdf.formatter</parmname></indexterm></indexterm>
               <indexterm>formatter</indexterm>
-              <indexterm>PDF<indexterm>formatter</indexterm></indexterm>
+              <indexterm>PDF
+                <indexterm>formatter</indexterm></indexterm>
             </pd>
           </plentry>
           <plentry id="publish.required.cleanup" importance="deprecated">
             <pt>
               <parmname>publish.required.cleanup</parmname>
-              <ph><indexterm>deprecated features<indexterm><parmname>publish.required.cleanup</parmname></indexterm></indexterm></ph>
+              <ph>
+                <indexterm>deprecated features
+                  <indexterm><parmname>publish.required.cleanup</parmname></indexterm></indexterm></ph>
             </pt>
             <pd conaction="mark" conref="parameters-pdf.dita#pdf/publish.required.cleanup.desc"/>
             <pd conaction="pushafter">The default value is the value of the <parmname>args.draft</parmname> parameter.
                 <ph audience="xslt-customizer">Corresponds to the XSLT parameter
                   <parmname>publishRequiredCleanup</parmname>.</ph><note type="notice">This parameter is deprecated in
                 favor of the <parmname>args.draft</parmname> parameter.
-                  <indexterm end="ant-xslt-params"/></note></pd>
+                <indexterm end="ant-xslt-params"/></note></pd>
           </plentry>
         </parml>
       </section>
@@ -650,7 +690,8 @@
             <pd conaction="mark" conref="parameters-xhtml.dita#xhtml/args.xhtml.contenttarget.desc"/>
             <pd conaction="pushafter">The default value is <option>contentwin</option>. Change this value to use a
               different target name for the table of contents.
-              <indexterm>table of contents<indexterm>XHTML</indexterm></indexterm>
+              <indexterm>table of contents
+                <indexterm>XHTML</indexterm></indexterm>
             </pd>
           </plentry>
         </parml>
@@ -665,8 +706,8 @@
     </titlealts>
     <shortdesc conaction="pushreplace" conref="parameters-html5.dita#html5/shortdesc">The HTML5 transformation shares
       common parameters with other HTML-based transformations and provides additional parameters that are specific to
-      HTML5 output.
-      <ph><indexterm>HTML5</indexterm></ph>
+      HTML5 output. <ph>
+        <indexterm>HTML5</indexterm></ph>
     </shortdesc>
     <refbody>
       <!-- args.html5.contenttarget is listed in generated topic, but does not appear in default HTML5 output files. -->
@@ -744,7 +785,9 @@
           <plentry id="args.hide.parent.link" importance="deprecated">
             <pt>
               <parmname>args.hide.parent.link</parmname>
-              <ph><indexterm>deprecated features<indexterm><parmname>args.hide.parent.link</parmname></indexterm></indexterm></ph>
+              <ph>
+                <indexterm>deprecated features
+                  <indexterm><parmname>args.hide.parent.link</parmname></indexterm></indexterm></ph>
             </pt>
             <pd conaction="mark" conref="parameters-html5.dita#html5/args.hide.parent.link.desc"/>
             <pd conaction="pushafter">
@@ -771,8 +814,9 @@
             <pt><parmname>nav-toc</parmname></pt>
             <pd conaction="pushreplace" conref="parameters-html5.dita#html5/nav-toc.desc">
               <p>Specifies whether to generate a table of contents (ToC) in the HTML5 <xmlelement>nav</xmlelement>
-                element of each page. The navigation can then be rendered in a sidebar or menu via CSS. 
-                <indexterm>HTML5<indexterm>nav-toc</indexterm></indexterm>
+                element of each page. The navigation can then be rendered in a sidebar or menu via CSS.
+                <indexterm>HTML5
+                  <indexterm>nav-toc</indexterm></indexterm>
               </p>
               <p>The following values are supported:
                 <ul>
@@ -782,8 +826,10 @@
                   <li><option>full</option> – Generate a complete ToC for the entire map</li>
                 </ul>
                 <div outputclass="div-index">
-                  <indexterm>table of contents<indexterm>HTML5</indexterm></indexterm>
-                  <indexterm>table of contents<indexterm>nav-toc</indexterm></indexterm>
+                  <indexterm>table of contents
+                    <indexterm>HTML5</indexterm></indexterm>
+                  <indexterm>table of contents
+                    <indexterm>nav-toc</indexterm></indexterm>
                 </div>
               </p>
             </pd>

--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -825,6 +825,7 @@
                     and children</li>
                   <li><option>full</option> – Generate a complete ToC for the entire map</li>
                 </ul>
+                <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
                 <div outputclass="div-index">
                   <indexterm>table of contents
                     <indexterm>HTML5</indexterm></indexterm>

--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -68,7 +68,7 @@
                 <indexterm>DITAVAL<indexterm><parmname>args.filter</parmname></indexterm></indexterm>
                 <indexterm>DITAVAL<index-see-also>filters</index-see-also></indexterm> <!-- https://github.com/dita-ot/dita-ot/issues/3319 -->
                 <indexterm>DITAVAL<index-see-also>profiling</index-see-also></indexterm>
-                <indexterm>OSX<index-see>macOS</index-see></indexterm>
+                <indexterm>OS X<index-see>macOS</index-see></indexterm>
                 <indexterm>macOS<indexterm>delimiter</indexterm></indexterm>
                 <indexterm>Linux<indexterm>delimiter</indexterm></indexterm>
                 <indexterm>Windows<indexterm>delimiter</indexterm></indexterm>

--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -32,7 +32,7 @@
                   <parmname>args.draft</parmname> parameter to <option>yes</option> causes the contents of the
                   <xmlelement>titlealts</xmlelement> element to be rendered below the title.
                 <indexterm><xmlelement>titlealts</xmlelement></indexterm>
-                <indexterm start="ant-xslt-params">XSLT</indexterm>
+                <indexterm>XSLT</indexterm>
                 <indexterm>draft
                   <indexterm>args.draft</indexterm>
                   <indexterm>PDF</indexterm></indexterm>
@@ -668,8 +668,7 @@
             <pd conaction="pushafter">The default value is the value of the <parmname>args.draft</parmname> parameter.
                 <ph audience="xslt-customizer">Corresponds to the XSLT parameter
                   <parmname>publishRequiredCleanup</parmname>.</ph><note type="notice">This parameter is deprecated in
-                favor of the <parmname>args.draft</parmname> parameter.
-                <indexterm end="ant-xslt-params"/></note></pd>
+                favor of the <parmname>args.draft</parmname> parameter.</note></pd>
           </plentry>
         </parml>
       </section>

--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -72,9 +72,12 @@
                 <indexterm>DITAVAL
                   <indexterm><parmname>args.filter</parmname></indexterm></indexterm>
                 <!-- https://github.com/dita-ot/dita-ot/issues/3319 -->
-                <indexterm>DITAVAL<index-see-also>filters</index-see-also></indexterm>
-                <indexterm>DITAVAL<index-see-also>profiling</index-see-also></indexterm>
-                <indexterm>OS X<index-see>macOS</index-see></indexterm>
+                <indexterm>DITAVAL
+                  <index-see-also>filters</index-see-also></indexterm>
+                <indexterm>DITAVAL
+                  <index-see-also>profiling</index-see-also></indexterm>
+                <indexterm>OS X
+                  <index-see>macOS</index-see></indexterm>
                 <indexterm>macOS
                   <indexterm>delimiter</indexterm></indexterm>
                 <indexterm>Linux
@@ -177,8 +180,9 @@
             <pd conaction="pushreplace" conref="parameters-base.dita#base/default.language.desc">Specifies the language
               that is used if the input file does not have the <xmlatt>xml:lang</xmlatt> attribute set on the root
               element. By default, this is set to <option>en</option>. The allowed values are those that are defined in
-              IETF BCP 47, <xref href="https://tools.ietf.org/html/bcp47" format="html" scope="external">Tags for
-                Identifying Languages</xref>.
+              IETF BCP 47,
+              <xref href="https://tools.ietf.org/html/bcp47" format="html" scope="external">Tags for Identifying
+                Languages</xref>.
               <indexterm><xmlatt>xml:lang</xmlatt></indexterm>
               <indexterm>IETF BCP 47</indexterm>
               <indexterm>languages
@@ -244,7 +248,8 @@
             </pt>
             <pd conaction="mark" conref="parameters-base.dita#base/generate.copy.outer.desc"/>
             <pd conaction="pushafter">
-              <p>See <xref keyref="generate-copy-outer"/> for more information.</p>
+              <p>See
+                <xref keyref="generate-copy-outer"/> for more information.</p>
             </pd>
           </plentry>
           <plentry id="onlytopic.in.map">
@@ -310,10 +315,10 @@
       <navtitle>HTML-based output</navtitle>
     </titlealts>
     <shortdesc conaction="pushreplace" conref="parameters-base-html.dita#base-html/shortdesc">Certain parameters apply
-      to all HTML-based transformation types: HTML5, XHTML, HTML&#xA0;Help, and Eclipse help.
-    <ph>
-      <indexterm>HTML5<indexterm>parameters</indexterm></indexterm>
-    </ph>
+      to all HTML-based transformation types: HTML5, XHTML, HTML&#xA0;Help, and Eclipse help. <ph>
+        <indexterm>HTML5
+          <indexterm>parameters</indexterm></indexterm>
+      </ph>
     </shortdesc>
     <refbody>
       <section>
@@ -483,8 +488,7 @@
               from <xmlelement>section</xmlelement>) would generate <codeph>class="section prereq"</codeph>. <ph
                 audience="xslt-customizer">Corresponds to the XSLT parameter
                 <parmname>PRESERVE-DITA-CLASS</parmname>.</ph><note>Beginning with DITA-OT release 1.5.2, the default
-                value is <option>yes</option>. For release 1.5 and 1.5.1, the default value was <option>no</option>.
-              </note>
+                value is <option>yes</option>. For release 1.5 and 1.5.1, the default value was <option>no</option>. </note>
               <indexterm><xmlelement>prereq</xmlelement></indexterm>
               <indexterm><xmlelement>section</xmlelement></indexterm>
             </pd>
@@ -612,7 +616,8 @@
                 FOP).
                 <indexterm>Apache FOP
                   <indexterm>I18N</indexterm></indexterm>
-                <indexterm>FOP<index-see>Apache FOP</index-see></indexterm>
+                <indexterm>FOP
+                  <index-see>Apache FOP</index-see></indexterm>
                 <indexterm>I18N
                   <indexterm><parmname>org.dita.pdf2.i18n.enabled</parmname></indexterm></indexterm>
                 <indexterm>fonts
@@ -629,7 +634,8 @@
               </ul>
               <note type="tip">If you don’t use custom character mappings, turning off font mapping makes it easier to
                 define custom fonts simply by changing font names in the XSL attributes files of your custom PDF
-                plug-in. For details, see <xref keyref="jelovirt-on-pdf2-i18n"/>.</note>
+                plug-in. For details, see
+                <xref keyref="jelovirt-on-pdf2-i18n"/>.</note>
             </pd>
           </plentry>
           <plentry id="outputFile.base">
@@ -730,8 +736,7 @@
             <pt>
               <parmname>args.csspath</parmname>
             </pt>
-            <pd conaction="pushreplace"
-                conref="parameters-html5.dita#html5/args.csspath.desc">
+            <pd conaction="pushreplace" conref="parameters-html5.dita#html5/args.csspath.desc">
               <div conref="./ant-parameters-details.dita#base-html/args.csspath.desc"/>
             </pd>
             <pd conaction="mark" conref="parameters-html5.dita#html5/args.csspath.desc"/>
@@ -824,13 +829,10 @@
                     and children</li>
                   <li><option>full</option> – Generate a complete ToC for the entire map</li>
                 </ul>
-                <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-                <div outputclass="div-index">
-                  <indexterm>table of contents
-                    <indexterm>HTML5</indexterm></indexterm>
-                  <indexterm>table of contents
-                    <indexterm>nav-toc</indexterm></indexterm>
-                </div>
+                <indexterm>table of contents
+                  <indexterm>HTML5</indexterm></indexterm>
+                <indexterm>table of contents
+                  <indexterm>nav-toc</indexterm></indexterm>
               </p>
             </pd>
           </plentry>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -80,6 +80,7 @@
     </section>
     <section>
       <title>Arguments</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><parmname>--input</parmname></indexterm>
         <indexterm><parmname>-i</parmname></indexterm>
@@ -179,6 +180,7 @@
     </section>
     <section>
       <title>Options</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><parmname>-o</parmname></indexterm>
         <indexterm><parmname>--output</parmname></indexterm>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -17,10 +17,12 @@
           <indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
         <indexterm><cmdname>dita</cmdname> command
           <indexterm>arguments list</indexterm></indexterm>
-        <indexterm>arguments<index-see-also><cmdname>dita</cmdname> command</index-see-also></indexterm>
+        <indexterm>arguments
+          <index-see-also><cmdname>dita</cmdname> command</index-see-also></indexterm>
         <indexterm>installing</indexterm>
         <indexterm>uninstalling</indexterm>
-        <indexterm>artlbl<index-see>args.artlbl</index-see></indexterm>
+        <indexterm>artlbl
+          <index-see>args.artlbl</index-see></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -80,20 +82,17 @@
     </section>
     <section>
       <title>Arguments</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><parmname>--input</parmname></indexterm>
-        <indexterm><parmname>-i</parmname></indexterm>
-        <indexterm><parmname>--format</parmname></indexterm>
-        <indexterm><parmname>-f</parmname></indexterm>
-        <indexterm><parmname>--install</parmname></indexterm>
-        <indexterm><parmname>--uninstall</parmname></indexterm>
-        <indexterm><parmname>--plugins</parmname></indexterm>
-        <indexterm><parmname>--transtypes</parmname></indexterm>
-        <indexterm><parmname>--help</parmname></indexterm>
-        <indexterm><parmname>-h</parmname></indexterm>
-        <indexterm><parmname>--version</parmname></indexterm>
-      </div>
+      <indexterm><parmname>--input</parmname></indexterm>
+      <indexterm><parmname>-i</parmname></indexterm>
+      <indexterm><parmname>--format</parmname></indexterm>
+      <indexterm><parmname>-f</parmname></indexterm>
+      <indexterm><parmname>--install</parmname></indexterm>
+      <indexterm><parmname>--uninstall</parmname></indexterm>
+      <indexterm><parmname>--plugins</parmname></indexterm>
+      <indexterm><parmname>--transtypes</parmname></indexterm>
+      <indexterm><parmname>--help</parmname></indexterm>
+      <indexterm><parmname>-h</parmname></indexterm>
+      <indexterm><parmname>--version</parmname></indexterm>
       <parml>
         <plentry>
           <pt>
@@ -180,28 +179,25 @@
     </section>
     <section>
       <title>Options</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><parmname>-o</parmname></indexterm>
-        <indexterm><parmname>--output</parmname></indexterm>
-        <indexterm><parmname>--filter</parmname></indexterm>
-        <indexterm><parmname>--force</parmname></indexterm>
-        <indexterm><parmname>--temp</parmname></indexterm>
-        <indexterm><parmname>-t</parmname></indexterm>
-        <indexterm><parmname>--verbose</parmname></indexterm>
-        <indexterm><parmname>-v</parmname></indexterm>
-        <indexterm><parmname>--debug</parmname></indexterm>
-        <indexterm><parmname>-d</parmname></indexterm>
-        <indexterm><parmname>--logfile</parmname></indexterm>
-        <indexterm><parmname>-l</parmname></indexterm>
-        <indexterm><parmname>--parameter</parmname></indexterm>
-        <indexterm><parmname>-D</parmname></indexterm>
-        <indexterm><parmname>--propertyfile</parmname></indexterm>
-        <indexterm>Java
-          <indexterm>classes</indexterm></indexterm>
-        <indexterm>debugging
-          <indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
-      </div>
+      <indexterm><parmname>-o</parmname></indexterm>
+      <indexterm><parmname>--output</parmname></indexterm>
+      <indexterm><parmname>--filter</parmname></indexterm>
+      <indexterm><parmname>--force</parmname></indexterm>
+      <indexterm><parmname>--temp</parmname></indexterm>
+      <indexterm><parmname>-t</parmname></indexterm>
+      <indexterm><parmname>--verbose</parmname></indexterm>
+      <indexterm><parmname>-v</parmname></indexterm>
+      <indexterm><parmname>--debug</parmname></indexterm>
+      <indexterm><parmname>-d</parmname></indexterm>
+      <indexterm><parmname>--logfile</parmname></indexterm>
+      <indexterm><parmname>-l</parmname></indexterm>
+      <indexterm><parmname>--parameter</parmname></indexterm>
+      <indexterm><parmname>-D</parmname></indexterm>
+      <indexterm><parmname>--propertyfile</parmname></indexterm>
+      <indexterm>Java
+        <indexterm>classes</indexterm></indexterm>
+      <indexterm>debugging
+        <indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
       <parml id="dita_build_options">
         <plentry>
           <pt>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -13,8 +13,10 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>filters<indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
-        <indexterm><cmdname>dita</cmdname> command<indexterm>arguments list</indexterm></indexterm>
+        <indexterm>filters
+          <indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
+        <indexterm><cmdname>dita</cmdname> command
+          <indexterm>arguments list</indexterm></indexterm>
         <indexterm>arguments<index-see-also><cmdname>dita</cmdname> command</index-see-also></indexterm>
         <indexterm>installing</indexterm>
         <indexterm>uninstalling</indexterm>
@@ -29,9 +31,11 @@
         <fragment>
           <groupseq>
             <kwd>dita</kwd>
-            <kwd>--input</kwd><oper>=</oper>
+            <kwd>--input</kwd>
+            <oper>=</oper>
             <var>file</var>
-            <kwd>--format</kwd><oper>=</oper>
+            <kwd>--format</kwd>
+            <oper>=</oper>
             <var>name</var>
             <groupcomp importance="optional">
               <var>options</var>
@@ -41,7 +45,8 @@
         <fragment>
           <groupseq>
             <kwd>dita</kwd>
-            <kwd>--install</kwd><oper>=</oper>
+            <kwd>--install</kwd>
+            <oper>=</oper>
             <groupchoice importance="optional">
               <var>filename</var>
               <var>URL</var>
@@ -51,7 +56,8 @@
         <fragment>
           <groupseq>
             <kwd>dita</kwd>
-            <kwd>--uninstall</kwd><oper>=</oper>
+            <kwd>--uninstall</kwd>
+            <oper>=</oper>
             <var>id</var>
           </groupseq>
         </fragment>
@@ -189,8 +195,10 @@
         <indexterm><parmname>--parameter</parmname></indexterm>
         <indexterm><parmname>-D</parmname></indexterm>
         <indexterm><parmname>--propertyfile</parmname></indexterm>
-        <indexterm>Java<indexterm>classes</indexterm></indexterm>
-        <indexterm>debugging<indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
+        <indexterm>Java
+          <indexterm>classes</indexterm></indexterm>
+        <indexterm>debugging
+          <indexterm><cmdname>dita</cmdname> command</indexterm></indexterm>
       </div>
       <parml id="dita_build_options">
         <plentry>

--- a/parameters/generate-copy-outer.dita
+++ b/parameters/generate-copy-outer.dita
@@ -40,6 +40,7 @@ topics/
 
     <section>
       <title>Exclude content outside the map directory</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>index<index-see-also>entry file</index-see-also></indexterm>
         <indexterm>entry file

--- a/parameters/generate-copy-outer.dita
+++ b/parameters/generate-copy-outer.dita
@@ -11,8 +11,10 @@
     <metadata>
       <keywords>
         <indexterm><parmname>generate.copy.outer</parmname></indexterm>
-        <indexterm>HTML<indexterm>files outside map directory</indexterm></indexterm>
-        <indexterm>DITA maps<indexterm>relative file locations</indexterm></indexterm>
+        <indexterm>HTML
+          <indexterm>files outside map directory</indexterm></indexterm>
+        <indexterm>DITA maps
+          <indexterm>relative file locations</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -40,7 +42,8 @@ topics/
       <title>Exclude content outside the map directory</title>
       <div outputclass="div-index">
         <indexterm>index<index-see-also>entry file</index-see-also></indexterm>
-        <indexterm>entry file<indexterm>broken links, reason for</indexterm></indexterm>
+        <indexterm>entry file
+          <indexterm>broken links, reason for</indexterm></indexterm>
       </div>
       <p>Let’s assume that you run the HTML5 transformation. By default, DITA-OT uses the
           <parmname>generate.copy.outer</parmname> parameter with a value of <option>1</option>, which means that no
@@ -74,7 +77,8 @@ commonrtl.css</pre></p>
         specified via <parmname>args.css</parmname>) will be copied to the root level of the output folder. To copy CSS
         files to an output subfolder named <filepath>css</filepath>, set <parmname>args.csspath</parmname> to
           <option>css</option>.
-        <indexterm>CSS<indexterm>copy to specific location</indexterm></indexterm>
+        <indexterm>CSS
+          <indexterm>copy to specific location</indexterm></indexterm>
       </note>
     </section>
   </conbody>

--- a/parameters/generate-copy-outer.dita
+++ b/parameters/generate-copy-outer.dita
@@ -40,12 +40,10 @@ topics/
 
     <section>
       <title>Exclude content outside the map directory</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>index<index-see-also>entry file</index-see-also></indexterm>
-        <indexterm>entry file
-          <indexterm>broken links, reason for</indexterm></indexterm>
-      </div>
+      <indexterm>index
+        <index-see-also>entry file</index-see-also></indexterm>
+      <indexterm>entry file
+        <indexterm>broken links, reason for</indexterm></indexterm>
       <p>Let’s assume that you run the HTML5 transformation. By default, DITA-OT uses the
           <parmname>generate.copy.outer</parmname> parameter with a value of <option>1</option>, which means that no
         output is generated for content that is located outside the DITA map directory.</p>

--- a/reference/implementation-dependent-features.dita
+++ b/reference/implementation-dependent-features.dita
@@ -20,6 +20,7 @@
   <refbody>
     <section id="section_jla_oqn_qc">
       <title>Chunking</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlatt>chunk</xmlatt>
           <indexterm>supported methods</indexterm></indexterm>
@@ -50,6 +51,7 @@
     </section>
     <section id="section_zaa_bgs_qc">
       <title>Filtering</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>revprop</xmlelement></indexterm>
         <indexterm><xmlatt>val</xmlatt></indexterm>
@@ -66,6 +68,7 @@
     </section>
     <section id="section_kjq_egs_qc">
       <title>Debugging attributes</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>debugging
           <indexterm>attributes</indexterm>
@@ -96,6 +99,7 @@
     </section>
     <section>
       <title>Map processing</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>topicref</xmlelement></indexterm>
         <indexterm>map processing</indexterm>
@@ -106,6 +110,7 @@
     </section>
     <section id="section_h3h_jsx_1h">
       <title>Link processing</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlatt>href</xmlatt></indexterm>
         <indexterm>link processing</indexterm>
@@ -117,6 +122,7 @@
     </section>
     <section>
       <title>Copy-to processing</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>shortdesc</xmlelement></indexterm>
         <indexterm><xmlatt>copy-to</xmlatt></indexterm>
@@ -126,6 +132,7 @@
     </section>
     <section>
       <title>Coderef processing</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>coderef</xmlelement></indexterm>
         <indexterm>encoding</indexterm>

--- a/reference/implementation-dependent-features.dita
+++ b/reference/implementation-dependent-features.dita
@@ -20,13 +20,10 @@
   <refbody>
     <section id="section_jla_oqn_qc">
       <title>Chunking</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlatt>chunk</xmlatt>
-          <indexterm>supported methods</indexterm></indexterm>
-        <indexterm><xmlatt>chunk</xmlatt>
-          <indexterm>error recovery</indexterm></indexterm>
-      </div>
+      <indexterm><xmlatt>chunk</xmlatt>
+        <indexterm>supported methods</indexterm></indexterm>
+      <indexterm><xmlatt>chunk</xmlatt>
+        <indexterm>error recovery</indexterm></indexterm>
       <p>DITA content can be divided or merged into new output documents in different ways, depending on the value of
         the <xmlatt>chunk</xmlatt> attribute.</p>
       <p>DITA-OT supports the following chunking methods:</p>
@@ -51,13 +48,10 @@
     </section>
     <section id="section_zaa_bgs_qc">
       <title>Filtering</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>revprop</xmlelement></indexterm>
-        <indexterm><xmlatt>val</xmlatt></indexterm>
-        <indexterm>filters
-          <indexterm>duplicate conditions</indexterm></indexterm>
-      </div>
+      <indexterm><xmlelement>revprop</xmlelement></indexterm>
+      <indexterm><xmlatt>val</xmlatt></indexterm>
+      <indexterm>filters
+        <indexterm>duplicate conditions</indexterm></indexterm>
       <p>Error recovery:</p>
       <ul>
         <li>When there are multiple <xmlelement>revprop</xmlelement> elements with the same <xmlatt>val</xmlatt>
@@ -68,15 +62,12 @@
     </section>
     <section id="section_kjq_egs_qc">
       <title>Debugging attributes</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>debugging
-          <indexterm>attributes</indexterm>
-          <indexterm>xtrf</indexterm>
-          <indexterm>xtrc</indexterm></indexterm>
+      <indexterm>debugging
+        <indexterm>attributes</indexterm>
         <indexterm>xtrf</indexterm>
-        <indexterm>xtrc</indexterm>
-      </div>
+        <indexterm>xtrc</indexterm></indexterm>
+      <indexterm>xtrf</indexterm>
+      <indexterm>xtrc</indexterm>
       <p>The debug attributes are populated as follows:</p>
       <dl>
         <dlentry>
@@ -99,22 +90,16 @@
     </section>
     <section>
       <title>Map processing</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>topicref</xmlelement></indexterm>
-        <indexterm>map processing</indexterm>
-      </div>
+      <indexterm><xmlelement>topicref</xmlelement></indexterm>
+      <indexterm>map processing</indexterm>
       <p>When a <xmlelement>topicref</xmlelement> element that references a map contains child
           <xmlelement>topicref</xmlelement> elements, the <msgnum>DOTX068W</msgnum> error is thrown and the child
           <xmlelement>topicref</xmlelement> elements are ignored. </p>
     </section>
     <section id="section_h3h_jsx_1h">
       <title>Link processing</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlatt>href</xmlatt></indexterm>
-        <indexterm>link processing</indexterm>
-      </div>
+      <indexterm><xmlatt>href</xmlatt></indexterm>
+      <indexterm>link processing</indexterm>
       <p>When the value of a hyperlink reference in the <xmlatt>href</xmlatt> attribute is not a valid URI reference,
         the <msgnum>DOTJ054E</msgnum> error is thrown. Depending on the
         <xref href="../parameters/parameters-base.dita#base/processing-mode">processing-mode</xref> setting, error
@@ -122,21 +107,15 @@
     </section>
     <section>
       <title>Copy-to processing</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>shortdesc</xmlelement></indexterm>
-        <indexterm><xmlatt>copy-to</xmlatt></indexterm>
-      </div>
+      <indexterm><xmlelement>shortdesc</xmlelement></indexterm>
+      <indexterm><xmlatt>copy-to</xmlatt></indexterm>
       <p>When the <xmlatt>copy-to</xmlatt> attribute is specified on a <xmlelement>topicref</xmlelement>, the content of
         the <xmlelement>shortdesc</xmlelement> element is not used to override the short description of the topic.</p>
     </section>
     <section>
       <title>Coderef processing</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>coderef</xmlelement></indexterm>
-        <indexterm>encoding</indexterm>
-      </div>
+      <indexterm><xmlelement>coderef</xmlelement></indexterm>
+      <indexterm>encoding</indexterm>
       <p>When <xmlelement>coderef</xmlelement> elements are used within code blocks to reference external files with
         literal code samples, the system default character set is used as the target file encoding unless a different
         character set is explicitly defined via the mechanisms described under

--- a/reference/implementation-dependent-features.dita
+++ b/reference/implementation-dependent-features.dita
@@ -21,8 +21,10 @@
     <section id="section_jla_oqn_qc">
       <title>Chunking</title>
       <div outputclass="div-index">
-        <indexterm><xmlatt>chunk</xmlatt><indexterm>supported methods</indexterm></indexterm>
-        <indexterm><xmlatt>chunk</xmlatt><indexterm>error recovery</indexterm></indexterm>
+        <indexterm><xmlatt>chunk</xmlatt>
+          <indexterm>supported methods</indexterm></indexterm>
+        <indexterm><xmlatt>chunk</xmlatt>
+          <indexterm>error recovery</indexterm></indexterm>
       </div>
       <p>DITA content can be divided or merged into new output documents in different ways, depending on the value of
         the <xmlatt>chunk</xmlatt> attribute.</p>
@@ -51,7 +53,8 @@
       <div outputclass="div-index">
         <indexterm><xmlelement>revprop</xmlelement></indexterm>
         <indexterm><xmlatt>val</xmlatt></indexterm>
-        <indexterm>filters<indexterm>duplicate conditions</indexterm></indexterm>
+        <indexterm>filters
+          <indexterm>duplicate conditions</indexterm></indexterm>
       </div>
       <p>Error recovery:</p>
       <ul>
@@ -64,7 +67,10 @@
     <section id="section_kjq_egs_qc">
       <title>Debugging attributes</title>
       <div outputclass="div-index">
-        <indexterm>debugging<indexterm>attributes</indexterm><indexterm>xtrf</indexterm><indexterm>xtrc</indexterm></indexterm>
+        <indexterm>debugging
+          <indexterm>attributes</indexterm>
+          <indexterm>xtrf</indexterm>
+          <indexterm>xtrc</indexterm></indexterm>
         <indexterm>xtrf</indexterm>
         <indexterm>xtrc</indexterm>
       </div>
@@ -83,7 +89,8 @@
     </section>
     <section id="section_dco_qgs_qc">
       <title>Image scaling</title>
-      <indexterm>images<indexterm>scaling</indexterm></indexterm>
+      <indexterm>images
+        <indexterm>scaling</indexterm></indexterm>
       <p>If both height and width attributes are given, the image is scaled non-uniformly.</p>
       <p>If the scale attribute is not an unsigned integer, no error or warning is thrown during preprocessing.</p>
     </section>

--- a/reference/preprocess-copyfiles.dita
+++ b/reference/preprocess-copyfiles.dita
@@ -14,7 +14,6 @@
         <indexterm>preprocessing<indexterm><codeph>copy-files</codeph></indexterm></indexterm>
         <indexterm><codeph>copy-files</codeph></indexterm>
         <indexterm>images<indexterm>copying</indexterm></indexterm>
-        <indexterm end="preprocessing"/>
       </keywords>
     </metadata>
   </prolog>

--- a/reference/preprocessing.dita
+++ b/reference/preprocessing.dita
@@ -10,7 +10,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>preprocessing<indexterm  start="preprocessing">modules</indexterm></indexterm>
+        <indexterm>preprocessing<indexterm>modules</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/release-notes/index.dita
+++ b/release-notes/index.dita
@@ -366,6 +366,7 @@
 
       <section id="enhancements">
         <title>Enhancements and changes</title>
+        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
         <div outputclass="div-index">
           <indexterm><xmlelement>steps</xmlelement></indexterm>
           <indexterm><xmlelement>section</xmlelement></indexterm>
@@ -486,6 +487,7 @@
 
       <section id="bugs">
         <title>Bugs</title>
+        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
         <div outputclass="div-index">
           <indexterm><xmlelement>topicgroup</xmlelement></indexterm>
           <indexterm><xmlelement>topichead</xmlelement></indexterm>

--- a/release-notes/index.dita
+++ b/release-notes/index.dita
@@ -185,8 +185,10 @@
           <indexterm>Vietnamese</indexterm>
           <indexterm>Saxon
             <indexterm>version</indexterm></indexterm>
-          <indexterm>media<index-see-also>images</index-see-also></indexterm>
-          <indexterm>video<index-see>media</index-see></indexterm>
+          <indexterm>media
+            <index-see-also>images</index-see-also></indexterm>
+          <indexterm>video
+            <index-see>media</index-see></indexterm>
         </keywords>
       </metadata>
     </prolog>
@@ -366,26 +368,23 @@
 
       <section id="enhancements">
         <title>Enhancements and changes</title>
-        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-        <div outputclass="div-index">
-          <indexterm><xmlelement>steps</xmlelement></indexterm>
-          <indexterm><xmlelement>section</xmlelement></indexterm>
-          <indexterm><xmlelement>example</xmlelement></indexterm>
-          <indexterm><xmlelement>prereq</xmlelement></indexterm>
-          <indexterm><xmlelement>stepsection</xmlelement></indexterm>
-          <indexterm><xmlelement>mapref</xmlelement></indexterm>
-          <indexterm><xmlelement>topicref</xmlelement></indexterm>
-          <indexterm>schema
-            <indexterm>RELAX NG</indexterm></indexterm>
-          <indexterm><cmdname>dita</cmdname> command
-            <indexterm>property values</indexterm></indexterm>
-          <indexterm>XSLT
-            <indexterm>file location</indexterm></indexterm>
-          <indexterm>Saxon
-            <indexterm>version</indexterm></indexterm>
-          <indexterm><xmlatt>conref</xmlatt>
-            <indexterm>empty</indexterm></indexterm>
-        </div>
+        <indexterm><xmlelement>steps</xmlelement></indexterm>
+        <indexterm><xmlelement>section</xmlelement></indexterm>
+        <indexterm><xmlelement>example</xmlelement></indexterm>
+        <indexterm><xmlelement>prereq</xmlelement></indexterm>
+        <indexterm><xmlelement>stepsection</xmlelement></indexterm>
+        <indexterm><xmlelement>mapref</xmlelement></indexterm>
+        <indexterm><xmlelement>topicref</xmlelement></indexterm>
+        <indexterm>schema
+          <indexterm>RELAX NG</indexterm></indexterm>
+        <indexterm><cmdname>dita</cmdname> command
+          <indexterm>property values</indexterm></indexterm>
+        <indexterm>XSLT
+          <indexterm>file location</indexterm></indexterm>
+        <indexterm>Saxon
+          <indexterm>version</indexterm></indexterm>
+        <indexterm><xmlatt>conref</xmlatt>
+          <indexterm>empty</indexterm></indexterm>
         <p>DITA Open Toolkit Release <keyword keyref="release"/> includes the following enhancements and changes to
           existing features:</p>
         <!-- https://github.com/dita-ot/dita-ot/issues?q=milestone%3A3.3+is%3Aclosed+label%3Aenhancement+sort%3Acreated-asc -->
@@ -487,35 +486,33 @@
 
       <section id="bugs">
         <title>Bugs</title>
-        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-        <div outputclass="div-index">
-          <indexterm><xmlelement>topicgroup</xmlelement></indexterm>
-          <indexterm><xmlelement>topichead</xmlelement></indexterm>
-          <indexterm><xmlelement>dt</xmlelement></indexterm>
-          <indexterm><xmlelement>tm</xmlelement></indexterm>
-          <indexterm><xmlatt>conref</xmlatt>
-            <indexterm>-dita-use-conref-target</indexterm></indexterm>
-          <indexterm><xmlatt>keyref</xmlatt></indexterm>
-          <indexterm><xmlatt>chunk</xmlatt>
-            <indexterm>processing changes</indexterm></indexterm>
-          <indexterm><xmlatt>id</xmlatt>
-            <indexterm><xmlelement>dt</xmlelement></indexterm></indexterm>
-          <indexterm>DITAVAL
-            <indexterm>duplicate conditions</indexterm>
-            <indexterm>change bars</indexterm></indexterm>
-          <indexterm>Linux
-            <indexterm>installation directory</indexterm></indexterm>
-          <indexterm>macOS
-            <indexterm>installation directory</indexterm></indexterm>
-          <indexterm>Windows
-            <indexterm>installation directory</indexterm></indexterm>
-          <indexterm>RELAX NG<index-see>schema</index-see></indexterm>
-          <indexterm>schema
-            <indexterm>RELAX NG</indexterm></indexterm>
-          <indexterm><cmdname>dita</cmdname> command
-            <indexterm>= (equals sign)</indexterm></indexterm>
-          <indexterm>nav-toc</indexterm>
-        </div>
+        <indexterm><xmlelement>topicgroup</xmlelement></indexterm>
+        <indexterm><xmlelement>topichead</xmlelement></indexterm>
+        <indexterm><xmlelement>dt</xmlelement></indexterm>
+        <indexterm><xmlelement>tm</xmlelement></indexterm>
+        <indexterm><xmlatt>conref</xmlatt>
+          <indexterm>-dita-use-conref-target</indexterm></indexterm>
+        <indexterm><xmlatt>keyref</xmlatt></indexterm>
+        <indexterm><xmlatt>chunk</xmlatt>
+          <indexterm>processing changes</indexterm></indexterm>
+        <indexterm><xmlatt>id</xmlatt>
+          <indexterm><xmlelement>dt</xmlelement></indexterm></indexterm>
+        <indexterm>DITAVAL
+          <indexterm>duplicate conditions</indexterm>
+          <indexterm>change bars</indexterm></indexterm>
+        <indexterm>Linux
+          <indexterm>installation directory</indexterm></indexterm>
+        <indexterm>macOS
+          <indexterm>installation directory</indexterm></indexterm>
+        <indexterm>Windows
+          <indexterm>installation directory</indexterm></indexterm>
+        <indexterm>RELAX NG
+          <index-see>schema</index-see></indexterm>
+        <indexterm>schema
+          <indexterm>RELAX NG</indexterm></indexterm>
+        <indexterm><cmdname>dita</cmdname> command
+          <indexterm>= (equals sign)</indexterm></indexterm>
+        <indexterm>nav-toc</indexterm>
         <p>DITA Open Toolkit Release <keyword keyref="release"/> provides fixes for the following bugs:</p>
         <!-- https://github.com/dita-ot/dita-ot/issues?q=milestone%3A3.3+is%3Aclosed+label%3Abug+sort%3Acreated-asc -->
         <ul>

--- a/release-notes/index.dita
+++ b/release-notes/index.dita
@@ -95,19 +95,24 @@
     <prolog>
       <metadata>
         <keywords>
-          <indexterm>HTML5<indexterm>table <xmlatt>headers</xmlatt></indexterm></indexterm>
+          <indexterm>HTML5
+            <indexterm>table <xmlatt>headers</xmlatt></indexterm></indexterm>
           <indexterm>flagging</indexterm>
           <indexterm><xmlatt>xml:lang</xmlatt></indexterm>
           <indexterm><xmlelement>linklist</xmlelement></indexterm>
-          <indexterm>languages<indexterm><xmlelement>linklist</xmlelement></indexterm></indexterm>
+          <indexterm>languages
+            <indexterm><xmlelement>linklist</xmlelement></indexterm></indexterm>
           <indexterm>link processing</indexterm>
           <indexterm>Trouble note labels</indexterm>
           <indexterm><xmlelement>note</xmlelement></indexterm>
           <indexterm>passthrough</indexterm>
-          <indexterm>DITAVAL<indexterm>passthrough action</indexterm></indexterm>
+          <indexterm>DITAVAL
+            <indexterm>passthrough action</indexterm></indexterm>
           <indexterm><xmlatt>action</xmlatt></indexterm>
           <indexterm><xmlelement>prop</xmlelement></indexterm>
-          <indexterm>Saxon<indexterm>tables</indexterm><indexterm>screen readers</indexterm></indexterm>
+          <indexterm>Saxon
+            <indexterm>tables</indexterm>
+            <indexterm>screen readers</indexterm></indexterm>
         </keywords>
       </metadata>
     </prolog>
@@ -178,7 +183,8 @@
           <indexterm>Danish</indexterm>
           <indexterm>Montenegrin</indexterm>
           <indexterm>Vietnamese</indexterm>
-          <indexterm>Saxon<indexterm>version</indexterm></indexterm>
+          <indexterm>Saxon
+            <indexterm>version</indexterm></indexterm>
           <indexterm>media<index-see-also>images</index-see-also></indexterm>
           <indexterm>video<index-see>media</index-see></indexterm>
         </keywords>
@@ -237,12 +243,15 @@
           <indexterm>registry</indexterm>
           <indexterm><xmlelement>draft-comment</xmlelement></indexterm>
           <indexterm><xmlelement>required-cleanup</xmlelement></indexterm>
-          <indexterm><xmlatt>conref</xmlatt><indexterm>multiple targets</indexterm></indexterm>
+          <indexterm><xmlatt>conref</xmlatt>
+            <indexterm>multiple targets</indexterm></indexterm>
           <indexterm><xmlatt>type</xmlatt></indexterm>
           <indexterm><xmlatt>conkeyref</xmlatt></indexterm>
-          <indexterm><cmdname>dita</cmdname> command<indexterm>plug-in registry</indexterm></indexterm>
+          <indexterm><cmdname>dita</cmdname> command
+            <indexterm>plug-in registry</indexterm></indexterm>
           <indexterm>integrator</indexterm>
-          <indexterm>transtype<indexterm>string</indexterm></indexterm>
+          <indexterm>transtype
+            <indexterm>string</indexterm></indexterm>
         </keywords>
       </metadata>
     </prolog>
@@ -307,8 +316,11 @@
         <keywords>
           <indexterm><xmlelement>entry</xmlelement></indexterm>
           <indexterm><xmlatt>rotate</xmlatt></indexterm>
-          <indexterm>DITA 1.3<indexterm><xmlatt>rotate</xmlatt></indexterm></indexterm>
-          <indexterm>tables<indexterm>attribute sets</indexterm><indexterm>rotated cells</indexterm></indexterm>
+          <indexterm>DITA 1.3
+            <indexterm><xmlatt>rotate</xmlatt></indexterm></indexterm>
+          <indexterm>tables
+            <indexterm>attribute sets</indexterm>
+            <indexterm>rotated cells</indexterm></indexterm>
         </keywords>
       </metadata>
     </prolog>
@@ -362,11 +374,16 @@
           <indexterm><xmlelement>stepsection</xmlelement></indexterm>
           <indexterm><xmlelement>mapref</xmlelement></indexterm>
           <indexterm><xmlelement>topicref</xmlelement></indexterm>
-          <indexterm>schema<indexterm>RELAX NG</indexterm></indexterm>
-          <indexterm><cmdname>dita</cmdname> command<indexterm>property values</indexterm></indexterm>
-          <indexterm>XSLT<indexterm>file location</indexterm></indexterm>
-          <indexterm>Saxon<indexterm>version</indexterm></indexterm>
-          <indexterm><xmlatt>conref</xmlatt><indexterm>empty</indexterm></indexterm>
+          <indexterm>schema
+            <indexterm>RELAX NG</indexterm></indexterm>
+          <indexterm><cmdname>dita</cmdname> command
+            <indexterm>property values</indexterm></indexterm>
+          <indexterm>XSLT
+            <indexterm>file location</indexterm></indexterm>
+          <indexterm>Saxon
+            <indexterm>version</indexterm></indexterm>
+          <indexterm><xmlatt>conref</xmlatt>
+            <indexterm>empty</indexterm></indexterm>
         </div>
         <p>DITA Open Toolkit Release <keyword keyref="release"/> includes the following enhancements and changes to
           existing features:</p>
@@ -474,17 +491,27 @@
           <indexterm><xmlelement>topichead</xmlelement></indexterm>
           <indexterm><xmlelement>dt</xmlelement></indexterm>
           <indexterm><xmlelement>tm</xmlelement></indexterm>
-          <indexterm><xmlatt>conref</xmlatt><indexterm>-dita-use-conref-target</indexterm></indexterm>
+          <indexterm><xmlatt>conref</xmlatt>
+            <indexterm>-dita-use-conref-target</indexterm></indexterm>
           <indexterm><xmlatt>keyref</xmlatt></indexterm>
-          <indexterm><xmlatt>chunk</xmlatt><indexterm>processing changes</indexterm></indexterm>
-          <indexterm><xmlatt>id</xmlatt><indexterm><xmlelement>dt</xmlelement></indexterm></indexterm>
-          <indexterm>DITAVAL<indexterm>duplicate conditions</indexterm><indexterm>change bars</indexterm></indexterm>
-          <indexterm>Linux<indexterm>installation directory</indexterm></indexterm>
-          <indexterm>macOS<indexterm>installation directory</indexterm></indexterm>
-          <indexterm>Windows<indexterm>installation directory</indexterm></indexterm>
+          <indexterm><xmlatt>chunk</xmlatt>
+            <indexterm>processing changes</indexterm></indexterm>
+          <indexterm><xmlatt>id</xmlatt>
+            <indexterm><xmlelement>dt</xmlelement></indexterm></indexterm>
+          <indexterm>DITAVAL
+            <indexterm>duplicate conditions</indexterm>
+            <indexterm>change bars</indexterm></indexterm>
+          <indexterm>Linux
+            <indexterm>installation directory</indexterm></indexterm>
+          <indexterm>macOS
+            <indexterm>installation directory</indexterm></indexterm>
+          <indexterm>Windows
+            <indexterm>installation directory</indexterm></indexterm>
           <indexterm>RELAX NG<index-see>schema</index-see></indexterm>
-          <indexterm>schema<indexterm>RELAX NG</indexterm></indexterm>
-          <indexterm><cmdname>dita</cmdname> command<indexterm>= (equals sign)</indexterm></indexterm>
+          <indexterm>schema
+            <indexterm>RELAX NG</indexterm></indexterm>
+          <indexterm><cmdname>dita</cmdname> command
+            <indexterm>= (equals sign)</indexterm></indexterm>
           <indexterm>nav-toc</indexterm>
         </div>
         <p>DITA Open Toolkit Release <keyword keyref="release"/> provides fixes for the following bugs:</p>

--- a/resources/reusable-components.dita
+++ b/resources/reusable-components.dita
@@ -98,6 +98,7 @@
       <p id="java-clients">DITA-OT is designed to run on Java version <keyword keyref="tool.java.version"/> or later and
         built and tested with the Open Java Development Kit (OpenJDK). Compatible Java distributions are available from
         multiple sources:
+        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
         <div outputclass="div-index">
           <indexterm>Java
             <indexterm>versions</indexterm></indexterm>

--- a/resources/reusable-components.dita
+++ b/resources/reusable-components.dita
@@ -98,14 +98,11 @@
       <p id="java-clients">DITA-OT is designed to run on Java version <keyword keyref="tool.java.version"/> or later and
         built and tested with the Open Java Development Kit (OpenJDK). Compatible Java distributions are available from
         multiple sources:
-        <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-        <div outputclass="div-index">
-          <indexterm>Java
-            <indexterm>versions</indexterm></indexterm>
-          <indexterm>Amazon Corretto</indexterm>
-          <indexterm>OpenJDK</indexterm>
-          <indexterm>Oracle JDK</indexterm>
-        </div>
+        <indexterm>Java
+          <indexterm>versions</indexterm></indexterm>
+        <indexterm>Amazon Corretto</indexterm>
+        <indexterm>OpenJDK</indexterm>
+        <indexterm>Oracle JDK</indexterm>
         <ul>
           <li>You can download the Oracle JRE or JDK from
             <xref keyref="download.oracle-jdk"/> under commercial license.</li>

--- a/resources/reusable-components.dita
+++ b/resources/reusable-components.dita
@@ -18,9 +18,12 @@
       <title>Upgrade stylesheets to XSLT 2.0</title>
       <indexterm>upgrading</indexterm>
       <indexterm>Saxon</indexterm>
-      <indexterm>XSLT<indexterm>1.0</indexterm></indexterm>
-      <indexterm>XSLT<indexterm>2.0</indexterm></indexterm>
-      <indexterm>plug-ins<indexterm>upgrading</indexterm></indexterm>
+      <indexterm>XSLT
+        <indexterm>1.0</indexterm></indexterm>
+      <indexterm>XSLT
+        <indexterm>2.0</indexterm></indexterm>
+      <indexterm>plug-ins
+        <indexterm>upgrading</indexterm></indexterm>
       <p>The Saxon project has announced plans to remove XSLT 1.0 support from the Saxon-HE library that ships with
         DITA-OT:</p>
       <lq href="https://www.xml.com/news/release-saxon-98/" format="html" scope="external">…we’re dropping XSLT 1.0
@@ -40,8 +43,9 @@
       <div id="plugin.rnc">
         <p>DITA-OT includes a RELAX NG schema file that can be used to validate the <filepath>plugin.xml</filepath>
           files that define the capabilities of each plug-in.
-        <indexterm>schema<indexterm>RELAX NG</indexterm></indexterm>
-        <indexterm>validate</indexterm>
+          <indexterm>schema
+            <indexterm>RELAX NG</indexterm></indexterm>
+          <indexterm>validate</indexterm>
         </p>
         <p>To ensure the syntax of your custom plug-in is correct, include an <xmlpi>xml-model</xmlpi> processing
           instruction at the beginning of the <filepath>plugin.xml</filepath> file, immediately after the XML
@@ -93,8 +97,10 @@
       <title>Supported Java versions</title>
       <p id="java-clients">DITA-OT is designed to run on Java version <keyword keyref="tool.java.version"/> or later and
         built and tested with the Open Java Development Kit (OpenJDK). Compatible Java distributions are available from
-        multiple sources: <div outputclass="div-index">
-          <indexterm>Java<indexterm>versions</indexterm></indexterm>
+        multiple sources:
+        <div outputclass="div-index">
+          <indexterm>Java
+            <indexterm>versions</indexterm></indexterm>
           <indexterm>Amazon Corretto</indexterm>
           <indexterm>OpenJDK</indexterm>
           <indexterm>Oracle JDK</indexterm>
@@ -114,8 +120,8 @@
       <title>Limitations of map-first pre-processing</title>
       <p id="no-internal-preprocess2-ext">The internal extension points that run before or after individual steps in the
         original <codeph>preprocess</codeph> pipeline (<codeph>preprocess.*.pre/preprocess.*.post</codeph>) are not
-        available in the newer map-first preprocessing pipeline (<codeph>preprocess2</codeph>), which is used in the 
-        PDF and HTML Help transformations as of DITA-OT 3.0.</p>
+        available in the newer map-first preprocessing pipeline (<codeph>preprocess2</codeph>), which is used in the PDF
+        and HTML Help transformations as of DITA-OT 3.0.</p>
     </section>
   </conbody>
 </concept>

--- a/topics/DITA-messages-details.xml
+++ b/topics/DITA-messages-details.xml
@@ -508,7 +508,7 @@
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX020E-extra" conaction="pushreplace">DITA-OT is only able to
           dynamically retrieve titles when the target is a local (not peer or external) DITA resource.
-        <indexterm start="navtitle">navtitle</indexterm>
+        <indexterm>navtitle</indexterm>
         </stentry>
       </strow>
       <strow>
@@ -532,8 +532,7 @@
       </strow>
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX025E-extra" conaction="pushreplace">DITA-OT is only able to
-          dynamically retrieve titles when the target is a local DITA resource.
-        <indexterm end="navtitle"/></stentry>
+          dynamically retrieve titles when the target is a local DITA resource.</stentry>
       </strow>
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX026W-extra" conaction="pushreplace">The referenc to this document

--- a/topics/alternative-input-formats.dita
+++ b/topics/alternative-input-formats.dita
@@ -13,7 +13,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm start="lwdita">Lightweight DITA</indexterm> <!-- https://github.com/dita-ot/dita-ot/issues/3318 -->
+        <indexterm>Lightweight DITA</indexterm>
         <indexterm>LwDITA<index-see>Lightweight DITA</index-see></indexterm>
         <indexterm>MDITA<index-see>Lightweight DITA</index-see></indexterm>
         <indexterm>XDITA<index-see>Lightweight DITA</index-see></indexterm>

--- a/topics/custom-plugins.dita
+++ b/topics/custom-plugins.dita
@@ -10,7 +10,7 @@
     <metadata>
       <keywords>
         <indexterm>DITA<indexterm>specializations</indexterm></indexterm>
-        <indexterm start="plugins">plug-ins</indexterm>
+        <indexterm>plug-ins</indexterm>
         <indexterm>plug-ins<indexterm>benefits</indexterm></indexterm>
         <indexterm>plug-ins<indexterm>working with</indexterm></indexterm>
       </keywords>

--- a/topics/html-customization-plugin-javascript.dita
+++ b/topics/html-customization-plugin-javascript.dita
@@ -15,7 +15,6 @@
         <indexterm><xmlelement>footer</xmlelement></indexterm>
         <indexterm><xmlelement>require</xmlelement></indexterm>
         <indexterm><xmlelement>head</xmlelement></indexterm>
-        <indexterm>transformations<indexterm end="html"/></indexterm> <!-- LE: This range is not appearing in the FOP index. -->
         <indexterm>HTML5<indexterm>JavaScript, adding</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/html-customization.dita
+++ b/topics/html-customization.dita
@@ -13,7 +13,7 @@
     <metadata>
       <keywords>
         <indexterm>HTML<indexterm>customizing</indexterm></indexterm>
-        <indexterm>transformations<indexterm start="html">HTML</indexterm></indexterm>
+        <indexterm>transformations<indexterm>HTML</indexterm></indexterm>
         <indexterm>plug-ins<indexterm>HTML5</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/implement-saxon-collation-uri-resolvers.dita
+++ b/topics/implement-saxon-collation-uri-resolvers.dita
@@ -16,8 +16,6 @@
         <indexterm><xmlatt>xsl:sort</xmlatt></indexterm>
         <indexterm>Chinese</indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm end="plugin-ideas"/></indexterm>
-        <indexterm>plug-ins<indexterm end="plugins-saxon"/></indexterm>
         <indexterm>XSLT<indexterm>URI resolver</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/implement-saxon-customizations.dita
+++ b/topics/implement-saxon-customizations.dita
@@ -17,7 +17,7 @@
         <indexterm>Saxon<index-see-also>Ant</index-see-also></indexterm>
         <indexterm>Ant<index-see-also>Saxon</index-see-also></indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm start="plugins-saxon">Saxon</indexterm></indexterm>
+        <indexterm>plug-ins<indexterm>Saxon</indexterm></indexterm>
         <indexterm>XSLT<indexterm>Saxon</indexterm></indexterm>
         <indexterm>preprocessing<indexterm>extension points, Saxon</indexterm></indexterm>
         <indexterm>Java<indexterm>ServiceLoader</indexterm></indexterm>

--- a/topics/log-files.dita
+++ b/topics/log-files.dita
@@ -75,6 +75,7 @@
     </section>
     <section>
       <title>FOP debug logging</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>logback.xml</indexterm>
         <indexterm>classpath

--- a/topics/log-files.dita
+++ b/topics/log-files.dita
@@ -17,7 +17,8 @@
         <indexterm>logging</indexterm>
         <indexterm>Ant
           <indexterm>logging</indexterm></indexterm>
-        <indexterm>debugging<index-see-also>logging</index-see-also></indexterm>
+        <indexterm>debugging
+          <index-see-also>logging</index-see-also></indexterm>
         <indexterm>Java
           <indexterm>logging</indexterm></indexterm>
       </keywords>
@@ -75,12 +76,9 @@
     </section>
     <section>
       <title>FOP debug logging</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>logback.xml</indexterm>
-        <indexterm>classpath
-          <indexterm>logging</indexterm></indexterm>
-      </div>
+      <indexterm>logback.xml</indexterm>
+      <indexterm>classpath
+        <indexterm>logging</indexterm></indexterm>
       <p>In PDF processing with <tm trademark="Apache" tmtype="tm">Apache</tm> FOP, DITA-OT 3.1 now uses the Simple
         Logging Facade for Java (SLF4J), allowing for better control and formatting of FOP log messages. To reduce noise
         on the console, all FOP messages are set to the Info level and hidden by default.</p>

--- a/topics/log-files.dita
+++ b/topics/log-files.dita
@@ -10,12 +10,16 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>Apache FOP<indexterm>log files</indexterm></indexterm>
-        <indexterm><cmdname>dita</cmdname> command<indexterm>logging</indexterm></indexterm>
+        <indexterm>Apache FOP
+          <indexterm>log files</indexterm></indexterm>
+        <indexterm><cmdname>dita</cmdname> command
+          <indexterm>logging</indexterm></indexterm>
         <indexterm>logging</indexterm>
-        <indexterm>Ant<indexterm>logging</indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm>logging</indexterm></indexterm>
         <indexterm>debugging<index-see-also>logging</index-see-also></indexterm>
-        <indexterm>Java<indexterm>logging</indexterm></indexterm>
+        <indexterm>Java
+          <indexterm>logging</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -73,7 +77,8 @@
       <title>FOP debug logging</title>
       <div outputclass="div-index">
         <indexterm>logback.xml</indexterm>
-        <indexterm>classpath<indexterm>logging</indexterm></indexterm>
+        <indexterm>classpath
+          <indexterm>logging</indexterm></indexterm>
       </div>
       <p>In PDF processing with <tm trademark="Apache" tmtype="tm">Apache</tm> FOP, DITA-OT 3.1 now uses the Simple
         Logging Facade for Java (SLF4J), allowing for better control and formatting of FOP log messages. To reduce noise

--- a/topics/lwdita-input.dita
+++ b/topics/lwdita-input.dita
@@ -15,9 +15,12 @@
       <keywords>
         <indexterm><xmlelement>topicref</xmlelement></indexterm>
         <indexterm><xmlatt>format</xmlatt></indexterm>
-        <indexterm>authoring formats<indexterm>Lightweight DITA</indexterm></indexterm>
-        <indexterm>metadata<indexterm>Lightweight DITA</indexterm></indexterm>
-        <indexterm>DITA 1.3<indexterm>Lightweight DITA</indexterm></indexterm>
+        <indexterm>authoring formats
+          <indexterm>Lightweight DITA</indexterm></indexterm>
+        <indexterm>metadata
+          <indexterm>Lightweight DITA</indexterm></indexterm>
+        <indexterm>DITA 1.3
+          <indexterm>Lightweight DITA</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/markdown-dita-syntax-reference.dita
+++ b/topics/markdown-dita-syntax-reference.dita
@@ -175,6 +175,7 @@ Context
 &lt;xref href="http://www.example.com/test.html" format="html" scope="external"&gt;External&lt;/xref&gt;</codeblock></section>
     <section id="images">
       <title>Images</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>images
           <indexterm>Markdown</indexterm></indexterm>
@@ -251,6 +252,7 @@ Context
       <p>Each definition entry must have only one term and contain only inline content.</p></section>
     <section id="tables">
       <title>Tables</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>tables
           <indexterm>Markdown</indexterm></indexterm>
@@ -289,6 +291,7 @@ Context
         Markdown DITA.</p></section>
     <section id="metadata">
       <title>Metadata</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>metadata
           <indexterm>Lightweight DITA</indexterm></indexterm>

--- a/topics/markdown-dita-syntax-reference.dita
+++ b/topics/markdown-dita-syntax-reference.dita
@@ -15,7 +15,8 @@
         <indexterm>Pandoc</indexterm>
         <indexterm end="lwdita"/>
         <indexterm>UTF</indexterm>
-        <indexterm>DITA<indexterm>specializations</indexterm></indexterm>
+        <indexterm>DITA
+          <indexterm>specializations</indexterm></indexterm>
         <indexterm>Markdown</indexterm>
         <indexterm>CommonMark</indexterm>
       </keywords>
@@ -175,7 +176,8 @@ Context
     <section id="images">
       <title>Images</title>
       <div outputclass="div-index">
-        <indexterm>images<indexterm>Markdown</indexterm></indexterm>
+        <indexterm>images
+          <indexterm>Markdown</indexterm></indexterm>
       </div>
       <p>Images used in inline content will result in inline placement. If a block level image contains a title, it will
         be treated as an image wrapped in
@@ -250,7 +252,8 @@ Context
     <section id="tables">
       <title>Tables</title>
       <div outputclass="div-index">
-        <indexterm>tables<indexterm>Markdown</indexterm></indexterm>
+        <indexterm>tables
+          <indexterm>Markdown</indexterm></indexterm>
       </div>
       <p>Tables use
         <xref format="html" href="http://fletcherpenney.net/multimarkdown/" scope="external">MultiMarkdown</xref> table
@@ -287,8 +290,10 @@ Context
     <section id="metadata">
       <title>Metadata</title>
       <div outputclass="div-index">
-        <indexterm>metadata<indexterm>Lightweight DITA</indexterm></indexterm>
-        <indexterm>metadata<indexterm>Markdown</indexterm></indexterm>
+        <indexterm>metadata
+          <indexterm>Lightweight DITA</indexterm></indexterm>
+        <indexterm>metadata
+          <indexterm>Markdown</indexterm></indexterm>
         <indexterm>Pandoc</indexterm>
       </div>
       <p>

--- a/topics/markdown-dita-syntax-reference.dita
+++ b/topics/markdown-dita-syntax-reference.dita
@@ -13,7 +13,6 @@
     <metadata>
       <keywords>
         <indexterm>Pandoc</indexterm>
-        <indexterm end="lwdita"/>
         <indexterm>UTF</indexterm>
         <indexterm>DITA
           <indexterm>specializations</indexterm></indexterm>

--- a/topics/markdown-dita-syntax-reference.dita
+++ b/topics/markdown-dita-syntax-reference.dita
@@ -174,11 +174,8 @@ Context
 &lt;xref href="http://www.example.com/test.html" format="html" scope="external"&gt;External&lt;/xref&gt;</codeblock></section>
     <section id="images">
       <title>Images</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>images
-          <indexterm>Markdown</indexterm></indexterm>
-      </div>
+      <indexterm>images
+        <indexterm>Markdown</indexterm></indexterm>
       <p>Images used in inline content will result in inline placement. If a block level image contains a title, it will
         be treated as an image wrapped in
       figure:</p><codeblock outputclass="language-markdown" xml:space="preserve">An inline ![Alt](test.jpg).
@@ -251,11 +248,8 @@ Context
       <p>Each definition entry must have only one term and contain only inline content.</p></section>
     <section id="tables">
       <title>Tables</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>tables
-          <indexterm>Markdown</indexterm></indexterm>
-      </div>
+      <indexterm>tables
+        <indexterm>Markdown</indexterm></indexterm>
       <p>Tables use
         <xref format="html" href="http://fletcherpenney.net/multimarkdown/" scope="external">MultiMarkdown</xref> table
         extension format:</p><codeblock outputclass="language-markdown" xml:space="preserve">| First Header | Second Header | Third Header |
@@ -290,14 +284,11 @@ Context
         Markdown DITA.</p></section>
     <section id="metadata">
       <title>Metadata</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>metadata
-          <indexterm>Lightweight DITA</indexterm></indexterm>
-        <indexterm>metadata
-          <indexterm>Markdown</indexterm></indexterm>
-        <indexterm>Pandoc</indexterm>
-      </div>
+      <indexterm>metadata
+        <indexterm>Lightweight DITA</indexterm></indexterm>
+      <indexterm>metadata
+        <indexterm>Markdown</indexterm></indexterm>
+      <indexterm>Pandoc</indexterm>
       <p>
         <xref format="html" href="http://www.yaml.org/" scope="external">YAML</xref> metadata block as defined in Pandoc
         <xref format="html#extension-yaml_metadata_block"

--- a/topics/migrating-to-1.5.4.dita
+++ b/topics/migrating-to-1.5.4.dita
@@ -30,7 +30,6 @@
         <indexterm>Russian</indexterm>
         <indexterm>Swedish</indexterm>
         <indexterm>I18N<indexterm><parmname>org.dita.pdf2.i18n.enabled</parmname></indexterm></indexterm>
-        <indexterm end="migrate"/>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/migrating-to-1.8.dita
+++ b/topics/migrating-to-1.8.dita
@@ -12,25 +12,40 @@
   <shortdesc>In DITA-OT 1.8, certain stylesheets were moved to plug-in specific folders and various deprecated Ant
     properties, XSLT stylesheets, parameters and modes were removed from the XHTML, PDF and ODT
     transformations.</shortdesc>
-  
+
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>deprecated features<indexterm><codeph>dita.script.dir</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>dita.resource.dir</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>dita.empty</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>args.message.file</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>ImgUtils</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><filepath>artwork-preprocessor.xsl</filepath></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><filepath>otdita2fo_frontend.xsl</filepath></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>insertVariable.old</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>XSLT mode, <codeph>layout-masters-processing</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>XSLT mode, <codeph>toc-prefix-text</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>XSLT mode, <codeph>toc-topic-text</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>args.fo.include.rellinks</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>Legacy PDF</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>args.odt.include.rellinks</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>disableRelatedLinks</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.script.dir</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.resource.dir</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.empty</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>args.message.file</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>ImgUtils</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><filepath>artwork-preprocessor.xsl</filepath></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><filepath>otdita2fo_frontend.xsl</filepath></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>insertVariable.old</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>XSLT mode, <codeph>layout-masters-processing</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>XSLT mode, <codeph>toc-prefix-text</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>XSLT mode, <codeph>toc-topic-text</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>args.fo.include.rellinks</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>Legacy PDF</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>args.odt.include.rellinks</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>disableRelatedLinks</codeph></indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -67,7 +82,9 @@
       <title>PDF</title>
       <div outputclass="div-index">
         <indexterm>args.rellinks</indexterm>
-        <indexterm>PDF<indexterm>related links</indexterm><indexterm>args.rellinks</indexterm></indexterm>
+        <indexterm>PDF
+          <indexterm>related links</indexterm>
+          <indexterm>args.rellinks</indexterm></indexterm>
       </div>
       <p>The following deprecated XSLT stylesheets have been removed:</p>
       <ul>

--- a/topics/migrating-to-1.8.dita
+++ b/topics/migrating-to-1.8.dita
@@ -80,13 +80,10 @@
     </section>
     <section>
       <title>PDF</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>args.rellinks</indexterm>
-        <indexterm>PDF
-          <indexterm>related links</indexterm>
-          <indexterm>args.rellinks</indexterm></indexterm>
-      </div>
+      <indexterm>args.rellinks</indexterm>
+      <indexterm>PDF
+        <indexterm>related links</indexterm>
+        <indexterm>args.rellinks</indexterm></indexterm>
       <p>The following deprecated XSLT stylesheets have been removed:</p>
       <ul>
         <li><filepath>artwork-preprocessor.xsl</filepath></li>

--- a/topics/migrating-to-1.8.dita
+++ b/topics/migrating-to-1.8.dita
@@ -80,6 +80,7 @@
     </section>
     <section>
       <title>PDF</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>args.rellinks</indexterm>
         <indexterm>PDF

--- a/topics/migrating-to-2.1.dita
+++ b/topics/migrating-to-2.1.dita
@@ -22,26 +22,46 @@
         <indexterm><xmlelement>term</xmlelement></indexterm>
         <indexterm><xmlelement>indexterm</xmlelement></indexterm>
         <indexterm><xmlatt>href</xmlatt></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>help</codeph> build target</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>imagefile</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>image.list</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>htmlfile</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>html.list</codeph></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>copy-subsidiary</codeph> target</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>copy-subsidiary-check</codeph> target</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>depend.preprocess.copy-subsidiary.pre</parmname> extension points</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>PDF, <codeph>insertVariable</codeph> template</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><varname>keydefs</varname> variable</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>KEYREF-FILE</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>displaytext</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>keys</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>target</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>pull-in-title</codeph> template</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>common-processing-phrase-within-link</codeph> template</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>dita.out.map.xhtml.toc</codeph> target</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>dita.out.map.htmlhelp.*</codeph> targets</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>dita.out.map.javahelp.*</codeph> targets</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>args.odt.img.embed</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>help</codeph> build target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>imagefile</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>image.list</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>htmlfile</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>html.list</codeph></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>copy-subsidiary</codeph> target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>copy-subsidiary-check</codeph> target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>depend.preprocess.copy-subsidiary.pre</parmname> extension points</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>PDF, <codeph>insertVariable</codeph> template</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><varname>keydefs</varname> variable</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>KEYREF-FILE</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>displaytext</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>keys</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>target</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>pull-in-title</codeph> template</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>common-processing-phrase-within-link</codeph> template</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.out.map.xhtml.toc</codeph> target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.out.map.htmlhelp.*</codeph> targets</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>dita.out.map.javahelp.*</codeph> targets</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>args.odt.img.embed</parmname></indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/migrating-to-2.1.dita
+++ b/topics/migrating-to-2.1.dita
@@ -144,6 +144,7 @@
 
     <section>
       <title>XHTML</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>keydef</indexterm>
       </div>
@@ -170,6 +171,7 @@
     </section>
     <section>
       <title>JavaHelp</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>JavaHelp</indexterm>
       </div>

--- a/topics/migrating-to-2.1.dita
+++ b/topics/migrating-to-2.1.dita
@@ -68,13 +68,15 @@
   <refbody>
     <section>
       <note>This topic provides a summary of changes in DITA-OT 2.1 that may require modifications to custom stylesheets
-        or plug-ins. For more information on changes in this release, see the <xref keyref="2.1-release-notes"/>.</note>
+        or plug-ins. For more information on changes in this release, see the
+        <xref keyref="2.1-release-notes"/>.</note>
     </section>
 
     <section>
       <p>The custom<systemoutput>FileUtils</systemoutput> code used to handle input and output in earlier versions of
-        DITA-OT has been replaced with the <xref href="http://commons.apache.org/proper/commons-io/" format="html"
-          scope="external">Apache Commons IO</xref> utilities library. </p>
+        DITA-OT has been replaced with the
+        <xref href="http://commons.apache.org/proper/commons-io/" format="html" scope="external">Apache Commons
+          IO</xref> utilities library. </p>
     </section>
 
     <section>
@@ -144,10 +146,7 @@
 
     <section>
       <title>XHTML</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>keydef</indexterm>
-      </div>
+      <indexterm>keydef</indexterm>
       <p>The <codeph>dita.<b>out.</b>map.xhtml.toc</codeph> target has been deprecated and should be replaced with the
         updated <codeph>dita.map.xhtml.toc</codeph> equivalent.</p>
       <p>Keydef processing has been removed from the XHTML rendering code. Keys are now resolved in one preprocessing
@@ -171,10 +170,7 @@
     </section>
     <section>
       <title>JavaHelp</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>JavaHelp</indexterm>
-      </div>
+      <indexterm>JavaHelp</indexterm>
       <p>The <codeph>dita.<b>out.</b>map.javahelp.*</codeph> targets have been deprecated and should be replaced with
         the updated <codeph>dita.map.javahelp.*</codeph> equivalents:</p>
       <ul>

--- a/topics/migrating-to-2.3.dita
+++ b/topics/migrating-to-2.3.dita
@@ -50,6 +50,7 @@
     </section>
     <section>
       <title>HTML-based formats</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>div</xmlelement>
           <indexterm><codeph>div.shortdesc</codeph></indexterm></indexterm>
@@ -74,6 +75,7 @@
     </section>
     <section>
       <title>PDF</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>deprecated features
           <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>

--- a/topics/migrating-to-2.3.dita
+++ b/topics/migrating-to-2.3.dita
@@ -36,32 +36,31 @@
   <refbody>
     <section>
       <note>This topic provides a summary of changes in DITA-OT 2.3 that may require modifications to custom stylesheets
-        or plug-ins. For more information on changes in this release, see the <xref keyref="2.3-release-notes"/>.</note>
+        or plug-ins. For more information on changes in this release, see the
+        <xref keyref="2.3-release-notes"/>.</note>
     </section>
     <section>
       <title>HTML5</title>
       <p>The <option>HTML5</option> table processing has been refactored to use valid HTML5 markup, HTML5 best
-        practices, and better CSS properties for styling. <xref href="https://en.bem.info/methodology/" format="html"
-          scope="external">BEM</xref>-style CSS classes are now generated with the name of the containing element, the
-        name of the attribute, and the value of the attribute. </p>
-      <p>Common CSS files are now generated using separate modules for each DITA domain, implemented as <xref
-          keyref="sass-lang"/> partials to better support extensions with CSS frameworks, custom plug-ins and future
+        practices, and better CSS properties for styling.
+        <xref href="https://en.bem.info/methodology/" format="html" scope="external">BEM</xref>-style CSS classes are
+        now generated with the name of the containing element, the name of the attribute, and the value of the
+        attribute. </p>
+      <p>Common CSS files are now generated using separate modules for each DITA domain, implemented as
+        <xref keyref="sass-lang"/> partials to better support extensions with CSS frameworks, custom plug-ins and future
         toolkit versions.</p>
     </section>
     <section>
       <title>HTML-based formats</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>div</xmlelement>
-          <indexterm><codeph>div.shortdesc</codeph></indexterm></indexterm>
-        <indexterm><xmlelement>p</xmlelement></indexterm>
-        <indexterm><xmlelement>abstract</xmlelement></indexterm>
-        <indexterm><xmlelement>simpletable</xmlelement></indexterm>
-        <indexterm><xmlelement>properties</xmlelement></indexterm>
-        <indexterm><xmlelement>choicetable</xmlelement></indexterm>
-        <indexterm>deprecated features
-          <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
-      </div>
+      <indexterm><xmlelement>div</xmlelement>
+        <indexterm><codeph>div.shortdesc</codeph></indexterm></indexterm>
+      <indexterm><xmlelement>p</xmlelement></indexterm>
+      <indexterm><xmlelement>abstract</xmlelement></indexterm>
+      <indexterm><xmlelement>simpletable</xmlelement></indexterm>
+      <indexterm><xmlelement>properties</xmlelement></indexterm>
+      <indexterm><xmlelement>choicetable</xmlelement></indexterm>
+      <indexterm>deprecated features
+        <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
       <p>The XSLT <codeph>tm-area</codeph> named template, which used to toggle rendering of trademark symbols in US
         English and Asian languages (Japanese, Korean, and both Chinese) but ignore them in all other languages, has
         been deprecated. Trademark symbols are now rendered uniformly for all languages and the template will be removed
@@ -75,19 +74,16 @@
     </section>
     <section>
       <title>PDF</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>deprecated features
-          <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
-        <indexterm>deprecated features
-          <indexterm>PDF localization variables</indexterm></indexterm>
-        <indexterm>deprecated features
-          <indexterm><parmname>conreffile</parmname></indexterm></indexterm>
-        <indexterm>deprecated features
-          <indexterm><parmname>conref-check</parmname> target</indexterm></indexterm>
-        <indexterm>deprecated features
-          <indexterm><parmname>coderef</parmname> target</indexterm></indexterm>
-      </div>
+      <indexterm>deprecated features
+        <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
+      <indexterm>deprecated features
+        <indexterm>PDF localization variables</indexterm></indexterm>
+      <indexterm>deprecated features
+        <indexterm><parmname>conreffile</parmname></indexterm></indexterm>
+      <indexterm>deprecated features
+        <indexterm><parmname>conref-check</parmname> target</indexterm></indexterm>
+      <indexterm>deprecated features
+        <indexterm><parmname>coderef</parmname> target</indexterm></indexterm>
       <p>The <codeph>antiquewhite</codeph> background color has been removed from table heads and key column contents in
           <xmlelement>simpletable</xmlelement> and <xmlelement>properties</xmlelement> tables to synchronize
         presentation with <xmlelement>choicetable</xmlelement> and provide a more uniform customization baseline between

--- a/topics/migrating-to-2.3.dita
+++ b/topics/migrating-to-2.3.dita
@@ -16,15 +16,20 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>languages<indexterm>supported</indexterm></indexterm>
+        <indexterm>languages
+          <indexterm>supported</indexterm></indexterm>
         <indexterm>Chinese</indexterm>
         <indexterm>English</indexterm>
         <indexterm>Indonesian</indexterm>
         <indexterm>Korean</indexterm>
-        <indexterm>I18N<indexterm>PDF processing</indexterm></indexterm>
-        <indexterm>metadata<indexterm>chunking, effect of</indexterm></indexterm>
-        <indexterm>tables<indexterm>HTML5</indexterm></indexterm>
-        <indexterm>tables<indexterm>PDF</indexterm></indexterm>
+        <indexterm>I18N
+          <indexterm>PDF processing</indexterm></indexterm>
+        <indexterm>metadata
+          <indexterm>chunking, effect of</indexterm></indexterm>
+        <indexterm>tables
+          <indexterm>HTML5</indexterm></indexterm>
+        <indexterm>tables
+          <indexterm>PDF</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -46,13 +51,15 @@
     <section>
       <title>HTML-based formats</title>
       <div outputclass="div-index">
-        <indexterm><xmlelement>div</xmlelement><indexterm><codeph>div.shortdesc</codeph></indexterm></indexterm>
+        <indexterm><xmlelement>div</xmlelement>
+          <indexterm><codeph>div.shortdesc</codeph></indexterm></indexterm>
         <indexterm><xmlelement>p</xmlelement></indexterm>
         <indexterm><xmlelement>abstract</xmlelement></indexterm>
         <indexterm><xmlelement>simpletable</xmlelement></indexterm>
         <indexterm><xmlelement>properties</xmlelement></indexterm>
         <indexterm><xmlelement>choicetable</xmlelement></indexterm>
-        <indexterm>deprecated features<indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
       </div>
       <p>The XSLT <codeph>tm-area</codeph> named template, which used to toggle rendering of trademark symbols in US
         English and Asian languages (Japanese, Korean, and both Chinese) but ignore them in all other languages, has
@@ -68,11 +75,16 @@
     <section>
       <title>PDF</title>
       <div outputclass="div-index">
-        <indexterm>deprecated features<indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm>PDF localization variables</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>conreffile</parmname></indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>conref-check</parmname> target</indexterm></indexterm>
-        <indexterm>deprecated features<indexterm><parmname>coderef</parmname> target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>tm-area</codeph> named template</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>PDF localization variables</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>conreffile</parmname></indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>conref-check</parmname> target</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><parmname>coderef</parmname> target</indexterm></indexterm>
       </div>
       <p>The <codeph>antiquewhite</codeph> background color has been removed from table heads and key column contents in
           <xmlelement>simpletable</xmlelement> and <xmlelement>properties</xmlelement> tables to synchronize

--- a/topics/migrating-to-2.4.dita
+++ b/topics/migrating-to-2.4.dita
@@ -11,11 +11,12 @@
 
   <shortdesc>In DITA-OT 2.4, the <option>HTML5</option> transformation was refactored as an independent plug-in that no
     longer depends on the <option>XHTML</option> plug-in. </shortdesc>
-  
+
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>deprecated features<indexterm><codeph>.notetitle</codeph> classes</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><codeph>.notetitle</codeph> classes</indexterm></indexterm>
         <indexterm>GitHub</indexterm>
       </keywords>
     </metadata>
@@ -66,10 +67,14 @@
         <indexterm>Eclipse Content</indexterm>
         <indexterm>OpenDocument Text</indexterm>
         <indexterm>RTF</indexterm>
-        <indexterm>plug-ins<indexterm>DocBook</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>Eclipse Content</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>OpenDocument Text</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>RTF</indexterm></indexterm>        
+        <indexterm>plug-ins
+          <indexterm>DocBook</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>Eclipse Content</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>OpenDocument Text</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>RTF</indexterm></indexterm>
       </div>
       <p>DITA-OT 2.4 no longer includes the following legacy transformation plug-ins in the default distribution:</p>
       <table outputclass="table-hover" frame="none" colsep="0" rowsep="1">

--- a/topics/migrating-to-2.4.dita
+++ b/topics/migrating-to-2.4.dita
@@ -62,21 +62,18 @@
     </section>
     <section id="24-legacy-plugin-removal">
       <title>Legacy plug-ins removed</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>DocBook</indexterm>
-        <indexterm>Eclipse Content</indexterm>
-        <indexterm>OpenDocument Text</indexterm>
-        <indexterm>RTF</indexterm>
-        <indexterm>plug-ins
-          <indexterm>DocBook</indexterm></indexterm>
-        <indexterm>plug-ins
-          <indexterm>Eclipse Content</indexterm></indexterm>
-        <indexterm>plug-ins
-          <indexterm>OpenDocument Text</indexterm></indexterm>
-        <indexterm>plug-ins
-          <indexterm>RTF</indexterm></indexterm>
-      </div>
+      <indexterm>DocBook</indexterm>
+      <indexterm>Eclipse Content</indexterm>
+      <indexterm>OpenDocument Text</indexterm>
+      <indexterm>RTF</indexterm>
+      <indexterm>plug-ins
+        <indexterm>DocBook</indexterm></indexterm>
+      <indexterm>plug-ins
+        <indexterm>Eclipse Content</indexterm></indexterm>
+      <indexterm>plug-ins
+        <indexterm>OpenDocument Text</indexterm></indexterm>
+      <indexterm>plug-ins
+        <indexterm>RTF</indexterm></indexterm>
       <p>DITA-OT 2.4 no longer includes the following legacy transformation plug-ins in the default distribution:</p>
       <table outputclass="table-hover" frame="none" colsep="0" rowsep="1">
         <title>Legacy plug-ins</title>

--- a/topics/migrating-to-2.4.dita
+++ b/topics/migrating-to-2.4.dita
@@ -62,6 +62,7 @@
     </section>
     <section id="24-legacy-plugin-removal">
       <title>Legacy plug-ins removed</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>DocBook</indexterm>
         <indexterm>Eclipse Content</indexterm>

--- a/topics/migrating-to-2.5.dita
+++ b/topics/migrating-to-2.5.dita
@@ -36,11 +36,8 @@
     </section>-->
     <section id="25-pdf-changes">
       <title>Default PDF style improvements</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>tables
-          <indexterm>indentation</indexterm></indexterm>
-      </div>
+      <indexterm>tables
+        <indexterm>indentation</indexterm></indexterm>
       <p>Several legacy styles have been modified or removed in the default PDF plug-in <codeph>org.dita.pdf2</codeph>,
         including the following:</p>
       <p>

--- a/topics/migrating-to-2.5.dita
+++ b/topics/migrating-to-2.5.dita
@@ -15,8 +15,10 @@
     <metadata>
       <keywords>
         <indexterm><xmlelement>example</xmlelement></indexterm>
-        <indexterm>PDF<indexterm><codeph>org.dita.pdf2.legacy</codeph></indexterm></indexterm>
-        <indexterm>languages<indexterm>right-to-left</indexterm></indexterm>
+        <indexterm>PDF
+          <indexterm><codeph>org.dita.pdf2.legacy</codeph></indexterm></indexterm>
+        <indexterm>languages
+          <indexterm>right-to-left</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -35,7 +37,8 @@
     <section id="25-pdf-changes">
       <title>Default PDF style improvements</title>
       <div outputclass="div-index">
-        <indexterm>tables<indexterm>indentation</indexterm></indexterm>
+        <indexterm>tables
+          <indexterm>indentation</indexterm></indexterm>
       </div>
       <p>Several legacy styles have been modified or removed in the default PDF plug-in <codeph>org.dita.pdf2</codeph>,
         including the following:</p>

--- a/topics/migrating-to-2.5.dita
+++ b/topics/migrating-to-2.5.dita
@@ -36,6 +36,7 @@
     </section>-->
     <section id="25-pdf-changes">
       <title>Default PDF style improvements</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>tables
           <indexterm>indentation</indexterm></indexterm>

--- a/topics/migrating-to-3.0.dita
+++ b/topics/migrating-to-3.0.dita
@@ -33,6 +33,7 @@
 
     <section id="30-legacy-plugin-removal">
       <title>Legacy plug-ins removed</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>JavaHelp</indexterm>
         <indexterm>deprecated features

--- a/topics/migrating-to-3.0.dita
+++ b/topics/migrating-to-3.0.dita
@@ -12,7 +12,7 @@
   <shortdesc>DITA-OT 3.0 <ph id="summary">adds support for Markdown, normalized DITA output, and the alternative
       authoring formats proposed for Lightweight DITA. The map-first preprocessing approach provides a modern
       alternative to the default <codeph>preprocess</codeph> operation.</ph></shortdesc>
-  
+
   <prolog>
     <metadata>
       <keywords>
@@ -35,8 +35,10 @@
       <title>Legacy plug-ins removed</title>
       <div outputclass="div-index">
         <indexterm>JavaHelp</indexterm>
-        <indexterm>deprecated features<indexterm>JavaHelp plug-in</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>JavaHelp</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm>JavaHelp plug-in</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>JavaHelp</indexterm></indexterm>
       </div>
       <p>DITA-OT 3.0 no longer includes the following legacy transformation plug-ins in the default distribution:</p>
       <table outputclass="table-hover" frame="none" colsep="0" rowsep="1">
@@ -52,7 +54,8 @@
           </thead>
           <tbody>
             <row>
-              <entry>JavaHelp<indexterm>JavaHelp</indexterm></entry>
+              <entry>JavaHelp
+                <indexterm>JavaHelp</indexterm></entry>
               <entry>
                 <xref href="https://github.com/dita-ot/org.dita.javahelp" format="html" scope="external"/></entry>
             </row>

--- a/topics/migrating-to-3.0.dita
+++ b/topics/migrating-to-3.0.dita
@@ -33,14 +33,11 @@
 
     <section id="30-legacy-plugin-removal">
       <title>Legacy plug-ins removed</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>JavaHelp</indexterm>
-        <indexterm>deprecated features
-          <indexterm>JavaHelp plug-in</indexterm></indexterm>
-        <indexterm>plug-ins
-          <indexterm>JavaHelp</indexterm></indexterm>
-      </div>
+      <indexterm>JavaHelp</indexterm>
+      <indexterm>deprecated features
+        <indexterm>JavaHelp plug-in</indexterm></indexterm>
+      <indexterm>plug-ins
+        <indexterm>JavaHelp</indexterm></indexterm>
       <p>DITA-OT 3.0 no longer includes the following legacy transformation plug-ins in the default distribution:</p>
       <table outputclass="table-hover" frame="none" colsep="0" rowsep="1">
         <title>Legacy plug-ins</title>

--- a/topics/migrating-to-3.3.dita
+++ b/topics/migrating-to-3.3.dita
@@ -17,7 +17,8 @@
         <indexterm>security</indexterm>
         <indexterm>TLS</indexterm>
         <indexterm>registry</indexterm>
-        <indexterm>tables<indexterm>PDF</indexterm></indexterm>
+        <indexterm>tables
+          <indexterm>PDF</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -68,7 +69,8 @@
       <title>Relocated catalog</title>
       <div outputclass="div-index">
         <indexterm><xmlelement>nextCatalog</xmlelement></indexterm>
-        <indexterm>catalog<indexterm>location</indexterm></indexterm>
+        <indexterm>catalog
+          <indexterm>location</indexterm></indexterm>
       </div>
       <p>
         <ph id="catalog">Along with the other base plug-in files, the <filepath>catalog-dita.xml</filepath> file has
@@ -88,8 +90,8 @@
       <title>Deprecated properties</title>
       <div outputclass="div-index">
         <indexterm><xmlelement>template</xmlelement></indexterm>
-        <indexterm>deprecated features<indexterm><filepath>plugin.xml</filepath>, <codeph>templates</codeph>
-          key</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><filepath>plugin.xml</filepath>, <codeph>templates</codeph> key</indexterm></indexterm>
       </div>
       <p><ph id="templates">The <codeph>templates</codeph> key in configuration properties has been deprecated in favor
           of the <xmlelement>template</xmlelement> element in <filepath>plugin.xml</filepath>.</ph></p>
@@ -99,8 +101,10 @@
       <title>New attribute sets for HTML5 customization</title>
       <div outputclass="div-index">
         <indexterm>Bootstrap</indexterm>
-        <indexterm>CSS<indexterm>HTML5</indexterm></indexterm>
-        <indexterm>HTML5<indexterm>CSS</indexterm></indexterm>
+        <indexterm>CSS
+          <indexterm>HTML5</indexterm></indexterm>
+        <indexterm>HTML5
+          <indexterm>CSS</indexterm></indexterm>
       </div>
       <p id="html5-att-sets">A series of new attribute sets has been added to the default HTML5 transformation to
         facilitate customization with additional ARIA roles, attributes, or CSS classes. Attribute sets are provided

--- a/topics/migrating-to-3.3.dita
+++ b/topics/migrating-to-3.3.dita
@@ -42,6 +42,7 @@
 
     <section>
       <title>Base plug-in files moved to <filepath>plugins</filepath> directory</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>xsl:include</xmlelement></indexterm>
         <indexterm><xmlelement>xsl:import</xmlelement></indexterm>
@@ -67,6 +68,7 @@
 
     <section>
       <title>Relocated catalog</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>nextCatalog</xmlelement></indexterm>
         <indexterm>catalog
@@ -88,6 +90,7 @@
 
     <section>
       <title>Deprecated properties</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>template</xmlelement></indexterm>
         <indexterm>deprecated features
@@ -99,6 +102,7 @@
 
     <section>
       <title>New attribute sets for HTML5 customization</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>Bootstrap</indexterm>
         <indexterm>CSS

--- a/topics/migrating-to-3.3.dita
+++ b/topics/migrating-to-3.3.dita
@@ -42,11 +42,8 @@
 
     <section>
       <title>Base plug-in files moved to <filepath>plugins</filepath> directory</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>xsl:include</xmlelement></indexterm>
-        <indexterm><xmlelement>xsl:import</xmlelement></indexterm>
-      </div>
+      <indexterm><xmlelement>xsl:include</xmlelement></indexterm>
+      <indexterm><xmlelement>xsl:import</xmlelement></indexterm>
       <p>Various XSLT files and other resources have been moved from the root of the DITA-OT installation directory to
         the base plug-in directory <filepath>plugins/org.dita.base</filepath>.</p>
       <note type="attention">There is no longer an <filepath>xsl/</filepath> directory in the installation root.</note>
@@ -68,12 +65,9 @@
 
     <section>
       <title>Relocated catalog</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>nextCatalog</xmlelement></indexterm>
-        <indexterm>catalog
-          <indexterm>location</indexterm></indexterm>
-      </div>
+      <indexterm><xmlelement>nextCatalog</xmlelement></indexterm>
+      <indexterm>catalog
+        <indexterm>location</indexterm></indexterm>
       <p>
         <ph id="catalog">Along with the other base plug-in files, the <filepath>catalog-dita.xml</filepath> file has
           been moved from the root of the DITA-OT installation directory to <filepath>plugins/org.dita.base</filepath>.
@@ -90,26 +84,20 @@
 
     <section>
       <title>Deprecated properties</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>template</xmlelement></indexterm>
-        <indexterm>deprecated features
-          <indexterm><filepath>plugin.xml</filepath>, <codeph>templates</codeph> key</indexterm></indexterm>
-      </div>
+      <indexterm><xmlelement>template</xmlelement></indexterm>
+      <indexterm>deprecated features
+        <indexterm><filepath>plugin.xml</filepath>, <codeph>templates</codeph> key</indexterm></indexterm>
       <p><ph id="templates">The <codeph>templates</codeph> key in configuration properties has been deprecated in favor
           of the <xmlelement>template</xmlelement> element in <filepath>plugin.xml</filepath>.</ph></p>
     </section>
 
     <section>
       <title>New attribute sets for HTML5 customization</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>Bootstrap</indexterm>
-        <indexterm>CSS
-          <indexterm>HTML5</indexterm></indexterm>
-        <indexterm>HTML5
-          <indexterm>CSS</indexterm></indexterm>
-      </div>
+      <indexterm>Bootstrap</indexterm>
+      <indexterm>CSS
+        <indexterm>HTML5</indexterm></indexterm>
+      <indexterm>HTML5
+        <indexterm>CSS</indexterm></indexterm>
       <p id="html5-att-sets">A series of new attribute sets has been added to the default HTML5 transformation to
         facilitate customization with additional ARIA roles, attributes, or CSS classes. Attribute sets are provided
         for:

--- a/topics/migration.dita
+++ b/topics/migration.dita
@@ -13,9 +13,7 @@
         <indexterm>upgrading<indexterm>plug-ins</indexterm></indexterm>
         <!-- LE: Only first alphabetical index-see-also prints in the index -->
         <indexterm>upgrading<index-see-also>migrating</index-see-also><index-see-also>installing</index-see-also></indexterm>
-        <indexterm>migrating</indexterm> <!-- LE: Build crash for the line above if this line does not exist even though
-        the line below does. Its existence causes duplicate page number to be emitted. Also, the line below does not generate a range. The @end is in migrating-to-1.5.4.dita. -->
-        <indexterm start="migrate">migrating</indexterm>
+        <indexterm>migrating</indexterm>
         <indexterm>plug-ins<indexterm>upgrading</indexterm></indexterm>
         <indexterm>installing</indexterm>
       </keywords>

--- a/topics/pdf-customization-approaches.dita
+++ b/topics/pdf-customization-approaches.dita
@@ -39,12 +39,9 @@
 
     <section id="the_customization_folder">
       <title>Using the <filepath>Customization</filepath> folder</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>deprecated features
-          <indexterm><filepath>Customization</filepath> folder</indexterm></indexterm>
-        <indexterm>Customization directory</indexterm>
-      </div>
+      <indexterm>deprecated features
+        <indexterm><filepath>Customization</filepath> folder</indexterm></indexterm>
+      <indexterm>Customization directory</indexterm>
       <p>The original Idiom plug-in used its own extension mechanism to provide overrides to the PDF transformation.
         With this approach, a dedicated folder within the plug-in is used to store customized files.</p>
       <p>Files in the <filepath>org.dita.pdf2/Customization</filepath> folder can override their default counterparts,

--- a/topics/pdf-customization-approaches.dita
+++ b/topics/pdf-customization-approaches.dita
@@ -8,13 +8,16 @@
     approaches have advantages and shortcomings that should be considered when preparing a customization project. Some
     of these methods are considered “anti-patterns” with disadvantages that outweigh their apparent appeal. In most
     cases, you should create a custom PDF plug-in.</shortdesc>
-  
+
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>PDF<indexterm>customizing, best practices</indexterm></indexterm>
-        <indexterm>upgrading<indexterm>default plug-ins</indexterm></indexterm>
-        <indexterm>upgrading<indexterm>PDF</indexterm></indexterm>
+        <indexterm>PDF
+          <indexterm>customizing, best practices</indexterm></indexterm>
+        <indexterm>upgrading
+          <indexterm>default plug-ins</indexterm></indexterm>
+        <indexterm>upgrading
+          <indexterm>PDF</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -25,7 +28,7 @@
       <p>When first experimenting with PDF customization, novice users are often tempted to simply edit the default
           <filepath>org.dita.pdf2</filepath> files in place to see what happens.</p>
       <p>As practical as this approach may seem, the DITA-OT project does not recommend changing any of the files in the
-          default plug-ins.</p>
+        default plug-ins.</p>
       <p>While this method yields quick results and can help users to determine which files and templates control
         various aspects of PDF output, it quickly leads to problems, as any errors may prevent the toolkit from
         generating PDF output.</p>
@@ -37,7 +40,8 @@
     <section id="the_customization_folder">
       <title>Using the <filepath>Customization</filepath> folder</title>
       <div outputclass="div-index">
-        <indexterm>deprecated features<indexterm><filepath>Customization</filepath> folder</indexterm></indexterm>
+        <indexterm>deprecated features
+          <indexterm><filepath>Customization</filepath> folder</indexterm></indexterm>
         <indexterm>Customization directory</indexterm>
       </div>
       <p>The original Idiom plug-in used its own extension mechanism to provide overrides to the PDF transformation.
@@ -60,8 +64,8 @@
 
     <section id="external_customization_directories">
       <title>Specifying an external customization directory</title>
-      <p>To ensure that overrides in customization folders are not overwritten when upgrading DITA-OT to a new
-        release, an external customization directory can be specified at build time or in build scripts via the
+      <p>To ensure that overrides in customization folders are not overwritten when upgrading DITA-OT to a new release,
+        an external customization directory can be specified at build time or in build scripts via the
           <parmname>customization.dir</parmname> parameter.</p>
       <p>This method is preferable to the use of the <filepath>org.dita.pdf2/Customization</filepath> folder, as the
         contents of external folders are unaffected when upgrading DITA-OT. In distributed environments, users can use

--- a/topics/pdf-customization-approaches.dita
+++ b/topics/pdf-customization-approaches.dita
@@ -39,6 +39,7 @@
 
     <section id="the_customization_folder">
       <title>Using the <filepath>Customization</filepath> folder</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>deprecated features
           <indexterm><filepath>Customization</filepath> folder</indexterm></indexterm>

--- a/topics/pdf-customization.dita
+++ b/topics/pdf-customization.dita
@@ -13,7 +13,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>transformations<indexterm start="pdf">PDF</indexterm></indexterm> <!-- LE: This is not generating a page range. -->
+        <indexterm>transformations<indexterm>PDF</indexterm></indexterm>
         <indexterm>PDF</indexterm>
       </keywords>
     </metadata>

--- a/topics/pdf-plugin-structure.dita
+++ b/topics/pdf-plugin-structure.dita
@@ -11,7 +11,7 @@
       <keywords>
         <indexterm>languages<indexterm>adding support for</indexterm></indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>PDF<indexterm start="pdf-plugin">plug-in</indexterm></indexterm>
+        <indexterm>PDF<indexterm>plug-in</indexterm></indexterm>
         <indexterm>font-mappings.xml</indexterm>
         <indexterm>fonts<indexterm>PDF</indexterm></indexterm>
         <indexterm>PDF<indexterm>fonts</indexterm></indexterm>

--- a/topics/pdf-plugin-structure_fo-xsl.dita
+++ b/topics/pdf-plugin-structure_fo-xsl.dita
@@ -9,7 +9,7 @@
     <prolog>
         <metadata>
             <keywords>
-                <indexterm end="pdf-plugin"/>
+                <indexterm/>
             </keywords>
         </metadata>
     </prolog>

--- a/topics/pdf2-creating-change-bars.dita
+++ b/topics/pdf2-creating-change-bars.dita
@@ -18,7 +18,7 @@
         <indexterm>Antenna House<indexterm>change bars</indexterm></indexterm>
         <indexterm>Apache FOP<indexterm>change bars</indexterm></indexterm>
         <indexterm>PDF<indexterm>change bars</indexterm></indexterm>
-        <indexterm>transformations<indexterm end="pdf"/></indexterm>
+        <indexterm>transformations</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/plugin-applications.dita
+++ b/topics/plugin-applications.dita
@@ -9,7 +9,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>plug-ins<indexterm start="plugin-ideas">ideas for</indexterm></indexterm>
+        <indexterm>plug-ins<indexterm>ideas for</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -13,7 +13,6 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm end="plugins"/>
         <indexterm>plug-ins
           <indexterm>best practices</indexterm></indexterm>
         <indexterm>XSLT

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -14,9 +14,12 @@
     <metadata>
       <keywords>
         <indexterm end="plugins"/>
-        <indexterm>plug-ins<indexterm>best practices</indexterm></indexterm>
-        <indexterm>XSLT<indexterm>best practices</indexterm></indexterm>
-        <indexterm>preprocessing<indexterm>XSLT</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>best practices</indexterm></indexterm>
+        <indexterm>XSLT
+          <indexterm>best practices</indexterm></indexterm>
+        <indexterm>preprocessing
+          <indexterm>XSLT</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -25,9 +28,12 @@
     <section>
       <title>Use custom <xmlelement>pipeline</xmlelement> elements</title>
       <div outputclass="div-index">
-        <indexterm>Ant<indexterm><xmlelement>pipeline</xmlelement></indexterm></indexterm>
-        <indexterm>Ant<indexterm><xmlelement>xslt</xmlelement></indexterm></indexterm>
-        <indexterm>Ant<indexterm><xmlelement>style</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>pipeline</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>xslt</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>style</xmlelement></indexterm></indexterm>
       </div>
       <p>In Ant scripts, use the XSLT module from DITA-OT instead of Ant’s built-in <xmlelement>xslt</xmlelement> or
           <xmlelement>style</xmlelement> tasks. </p>
@@ -62,9 +68,11 @@
     <section>
       <title>Use <xmlelement>ditafileset</xmlelement> to select files</title>
       <div outputclass="div-index">
-        <indexterm>Ant<indexterm><xmlelement>ditafileset</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>ditafileset</xmlelement></indexterm></indexterm>
         <indexterm><xmlelement>ditafileset</xmlelement></indexterm>
-        <indexterm>images<indexterm>selecting</indexterm></indexterm>
+        <indexterm>images
+          <indexterm>selecting</indexterm></indexterm>
         <indexterm>images<index-see-also>copy-files</index-see-also></indexterm>
       </div>
       <p>In Ant scripts, use <xmlelement>ditafileset</xmlelement> to select resources in the temporary directory.</p>
@@ -117,8 +125,10 @@
     <section>
       <title>Use the <codeph>plugin</codeph> URI scheme</title>
       <div outputclass="div-index">
-        <indexterm>Ant<indexterm><xmlelement>xsl:import</xmlelement></indexterm></indexterm>
-        <indexterm>Ant<indexterm><xmlelement>xsl:include</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>xsl:import</xmlelement></indexterm></indexterm>
+        <indexterm>Ant
+          <indexterm><xmlelement>xsl:include</xmlelement></indexterm></indexterm>
       </div>
       <p>In XSLT, use the <codeph>plugin</codeph> URI scheme in <xmlelement>xsl:import</xmlelement> and
           <xmlelement>xsl:include</xmlelement> to reference files in other plug-ins.</p>

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -26,15 +26,12 @@
     <section conkeyref="reusable-components/use-xslt2"/>
     <section>
       <title>Use custom <xmlelement>pipeline</xmlelement> elements</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>Ant
-          <indexterm><xmlelement>pipeline</xmlelement></indexterm></indexterm>
-        <indexterm>Ant
-          <indexterm><xmlelement>xslt</xmlelement></indexterm></indexterm>
-        <indexterm>Ant
-          <indexterm><xmlelement>style</xmlelement></indexterm></indexterm>
-      </div>
+      <indexterm>Ant
+        <indexterm><xmlelement>pipeline</xmlelement></indexterm></indexterm>
+      <indexterm>Ant
+        <indexterm><xmlelement>xslt</xmlelement></indexterm></indexterm>
+      <indexterm>Ant
+        <indexterm><xmlelement>style</xmlelement></indexterm></indexterm>
       <p>In Ant scripts, use the XSLT module from DITA-OT instead of Ant’s built-in <xmlelement>xslt</xmlelement> or
           <xmlelement>style</xmlelement> tasks. </p>
       <p>The XSLT module allows access to DITA-OT features like using the job configuration to select files in the
@@ -67,15 +64,13 @@
 
     <section>
       <title>Use <xmlelement>ditafileset</xmlelement> to select files</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>Ant
-          <indexterm><xmlelement>ditafileset</xmlelement></indexterm></indexterm>
-        <indexterm><xmlelement>ditafileset</xmlelement></indexterm>
-        <indexterm>images
-          <indexterm>selecting</indexterm></indexterm>
-        <indexterm>images<index-see-also>copy-files</index-see-also></indexterm>
-      </div>
+      <indexterm>Ant
+        <indexterm><xmlelement>ditafileset</xmlelement></indexterm></indexterm>
+      <indexterm><xmlelement>ditafileset</xmlelement></indexterm>
+      <indexterm>images
+        <indexterm>selecting</indexterm></indexterm>
+      <indexterm>images
+        <index-see-also>copy-files</index-see-also></indexterm>
       <p>In Ant scripts, use <xmlelement>ditafileset</xmlelement> to select resources in the temporary directory.</p>
       <p>For example, to select all images referenced by input DITA files, instead of:</p>
       <p><codeblock outputclass="language-xml normalize-space show-line-numbers show-whitespace">&lt;copy todir="${copy-image.todir}">
@@ -125,13 +120,10 @@
 
     <section>
       <title>Use the <codeph>plugin</codeph> URI scheme</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>Ant
-          <indexterm><xmlelement>xsl:import</xmlelement></indexterm></indexterm>
-        <indexterm>Ant
-          <indexterm><xmlelement>xsl:include</xmlelement></indexterm></indexterm>
-      </div>
+      <indexterm>Ant
+        <indexterm><xmlelement>xsl:import</xmlelement></indexterm></indexterm>
+      <indexterm>Ant
+        <indexterm><xmlelement>xsl:include</xmlelement></indexterm></indexterm>
       <p>In XSLT, use the <codeph>plugin</codeph> URI scheme in <xmlelement>xsl:import</xmlelement> and
           <xmlelement>xsl:include</xmlelement> to reference files in other plug-ins.</p>
       <p>Instead of:</p>

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -27,6 +27,7 @@
     <section conkeyref="reusable-components/use-xslt2"/>
     <section>
       <title>Use custom <xmlelement>pipeline</xmlelement> elements</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>Ant
           <indexterm><xmlelement>pipeline</xmlelement></indexterm></indexterm>
@@ -67,6 +68,7 @@
 
     <section>
       <title>Use <xmlelement>ditafileset</xmlelement> to select files</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>Ant
           <indexterm><xmlelement>ditafileset</xmlelement></indexterm></indexterm>
@@ -124,6 +126,7 @@
 
     <section>
       <title>Use the <codeph>plugin</codeph> URI scheme</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>Ant
           <indexterm><xmlelement>xsl:import</xmlelement></indexterm></indexterm>

--- a/topics/plugin-configfile.dita
+++ b/topics/plugin-configfile.dita
@@ -23,11 +23,8 @@
     <section conkeyref="reusable-components/validating-plugins"/>
     <section>
       <title>Plug-in identifiers</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlatt>id</xmlatt>
-          <indexterm>plug-in</indexterm></indexterm>
-      </div>
+      <indexterm><xmlatt>id</xmlatt>
+        <indexterm>plug-in</indexterm></indexterm>
       <p>Every DITA-OT plug-in must have a unique identifier composed of one or more dot-delimited tokens, for example,
           <codeph>com.example.rss</codeph>. This identifier is used to identify the plug-in to the toolkit for
         installation, processing, and when determining plug-in dependencies.</p>
@@ -53,10 +50,7 @@
     </section>
     <section>
       <title>Plug-in elements</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm><xmlelement>plugin</xmlelement></indexterm>
-      </div>
+      <indexterm><xmlelement>plugin</xmlelement></indexterm>
       <draft-comment author="Kristen Eberlein" time="13 May 2013">Perhaps all the following tables should have a Data
         type column? That would match with the DITA spec; also, it seems as if some attributes must take a predefined
         set of values.</draft-comment>

--- a/topics/plugin-configfile.dita
+++ b/topics/plugin-configfile.dita
@@ -10,9 +10,12 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>plug-ins<indexterm>identfiers</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm><filepath>plugin.xml</filepath></indexterm></indexterm>
-        <indexterm>metadata<indexterm>plug-in</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>identfiers</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm><filepath>plugin.xml</filepath></indexterm></indexterm>
+        <indexterm>metadata
+          <indexterm>plug-in</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -21,7 +24,8 @@
     <section>
       <title>Plug-in identifiers</title>
       <div outputclass="div-index">
-        <indexterm><xmlatt>id</xmlatt><indexterm>plug-in</indexterm></indexterm>
+        <indexterm><xmlatt>id</xmlatt>
+          <indexterm>plug-in</indexterm></indexterm>
       </div>
       <p>Every DITA-OT plug-in must have a unique identifier composed of one or more dot-delimited tokens, for example,
           <codeph>com.example.rss</codeph>. This identifier is used to identify the plug-in to the toolkit for
@@ -234,7 +238,8 @@
         <plentry>
           <pt><xmlelement>transtype</xmlelement></pt>
           <pd>
-            <indexterm><xmlelement>transtype</xmlelement><indexterm><filepath>plugin.xml</filepath></indexterm></indexterm>
+            <indexterm><xmlelement>transtype</xmlelement>
+              <indexterm><filepath>plugin.xml</filepath></indexterm></indexterm>
             <p>An optional element that defines a new output format (transformation type).</p>
             <p>The following attributes are supported:</p>
             <simpletable keycol="1">
@@ -271,7 +276,7 @@
               <title>Sample <xmlelement>transtype</xmlelement> element</title>
               <codeblock outputclass="language-xml">&lt;transtype name="base" abstract="true" desc="Common">
   &lt;!-- ⋮ -->
-  &lt;param name="link-crawl" 
+  &lt;param name="link-crawl"
          desc="Specifies whether to crawl only topic links found in maps, or all discovered topic links."
          type="enum">
     &lt;val>map&lt;/val>

--- a/topics/plugin-configfile.dita
+++ b/topics/plugin-configfile.dita
@@ -23,6 +23,7 @@
     <section conkeyref="reusable-components/validating-plugins"/>
     <section>
       <title>Plug-in identifiers</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlatt>id</xmlatt>
           <indexterm>plug-in</indexterm></indexterm>
@@ -52,6 +53,7 @@
     </section>
     <section>
       <title>Plug-in elements</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm><xmlelement>plugin</xmlelement></indexterm>
       </div>

--- a/topics/plugins-registry.dita
+++ b/topics/plugins-registry.dita
@@ -13,12 +13,17 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>PDF<indexterm>plug-in</indexterm></indexterm>
-        <indexterm><cmdname>dita</cmdname> command<indexterm>plug-in registry</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>registry</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm>installing</indexterm></indexterm>
+        <indexterm>PDF
+          <indexterm>plug-in</indexterm></indexterm>
+        <indexterm><cmdname>dita</cmdname> command
+          <indexterm>plug-in registry</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>registry</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>installing</indexterm></indexterm>
         <indexterm>GitHub</indexterm>
-        <indexterm>plug-ins<indexterm>URL</indexterm></indexterm>
+        <indexterm>plug-ins
+          <indexterm>URL</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -131,9 +136,12 @@
             href="https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-6"
             format="html" scope="external">Get-FileHash</xref> <varname>&lt;plugin-file&gt;</varname> |
           Format-List</codeph>.
-        <indexterm>macOS<indexterm>plug-in registry checksum</indexterm></indexterm>
-        <indexterm>Linux<indexterm>plug-in registry checksum</indexterm></indexterm>
-        <indexterm>Windows<indexterm>plug-in registry checksum</indexterm></indexterm>
+        <indexterm>macOS
+          <indexterm>plug-in registry checksum</indexterm></indexterm>
+        <indexterm>Linux
+          <indexterm>plug-in registry checksum</indexterm></indexterm>
+        <indexterm>Windows
+          <indexterm>plug-in registry checksum</indexterm></indexterm>
       </note>
       <table outputclass="table-hover" frame="none" colsep="0" rowsep="1">
         <title>Structure for dependency entries</title>

--- a/topics/plugins-registry.dita
+++ b/topics/plugins-registry.dita
@@ -8,8 +8,8 @@
     <navtitle>Plug-in registry</navtitle>
   </titlealts>
   <shortdesc><ph id="registry-summary">DITA-OT 3.2 supports a new plug-in registry that makes it easier to discover and
-      install new plug-ins. The registry provides a searchable list of plug-ins at <xref keyref="site-plugin-registry"
-      />.</ph></shortdesc>
+      install new plug-ins. The registry provides a searchable list of plug-ins at
+      <xref keyref="site-plugin-registry"/>.</ph></shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -36,8 +36,8 @@
     </section>
     <section id="using-the-registry">
       <title>Installing plug-ins from the registry</title>
-      <p>With the registry, you can now search the list of available plug-ins at <xref keyref="site-plugin-registry"/>
-        and install new plug-ins by name and optional version.</p>
+      <p>With the registry, you can now search the list of available plug-ins at
+        <xref keyref="site-plugin-registry"/> and install new plug-ins by name and optional version.</p>
       <p>Search the registry for a plug-in and install it by providing the plug-in name to the <cmdname>dita</cmdname>
         command.</p>
       <codeblock><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;</varname></codeblock>
@@ -57,12 +57,14 @@
       </ul>
     </section>
     <section id="publishing-to-registry"><title>Publishing plug-ins to the registry</title>
-      <p>The contents of the DITA Open Toolkit plug-in registry are stored in a Git repository at <xref
-          keyref="registry-repo"/>. New plug-ins or new versions can be added by sending a <xref keyref="pull-request"/>
-        that includes a single new plug-in entry in JavaScript Object Notation (JSON) format.</p>
+      <p>The contents of the DITA Open Toolkit plug-in registry are stored in a Git repository at
+        <xref keyref="registry-repo"/>. New plug-ins or new versions can be added by sending a
+        <xref keyref="pull-request"/> that includes a single new plug-in entry in JavaScript Object Notation (JSON)
+        format.</p>
       <note>As for all other contributions to the project, pull requests to the registry must be signed off by passing
         the <codeph>--signoff</codeph> option to the <cmdname>git commit</cmdname> command to certify that you have the
-        rights to submit this contribution. For more information on this process, see <xref keyref="signoff"/>.</note>
+        rights to submit this contribution. For more information on this process, see
+        <xref keyref="signoff"/>.</note>
       <p>The version entries for each plug-in are stored in a file that is named after the plug-in ID as
           <codeph>&lt;plugin-name&gt;.json</codeph>. The file contains an array of entries with a pre-defined structure.
         You should have one entry for each supported version of the plug-in.</p>
@@ -88,7 +90,8 @@
             <row>
               <entry><codeph>vers</codeph></entry>
               <entry>yes</entry>
-              <entry>Plug-in version in <xref keyref="semver"/> format</entry>
+              <entry>Plug-in version in
+                <xref keyref="semver"/> format</entry>
             </row>
             <row>
               <entry><codeph>deps</codeph></entry>
@@ -124,15 +127,15 @@
             <row>
               <entry><codeph>license</codeph></entry>
               <entry>no</entry>
-              <entry>License in <xref href="https://spdx.org/licenses/" format="html" scope="external">SPDX</xref>
-                format</entry>
+              <entry>License in
+                <xref href="https://spdx.org/licenses/" format="html" scope="external">SPDX</xref> format</entry>
             </row>
           </tbody>
         </tgroup>
       </table>
       <note type="tip">To calculate the SHA-256 checksum for the <codeph>cksum</codeph> key, use <codeph>shasum -a 256
-            <varname>&lt;plugin-file&gt;</varname></codeph> on macOS or Linux. With Windows PowerShell, use
-            <codeph><xref
+            <varname>&lt;plugin-file&gt;</varname></codeph> on macOS or Linux. With Windows PowerShell, use <codeph>
+          <xref
             href="https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-6"
             format="html" scope="external">Get-FileHash</xref> <varname>&lt;plugin-file&gt;</varname> |
           Format-List</codeph>.
@@ -165,26 +168,28 @@
             <row>
               <entry><codeph>req</codeph></entry>
               <entry>yes</entry>
-              <entry>Required plug-in version in <xref keyref="semver"/> format that may contain <xref
-                  href="https://docs.npmjs.com/misc/semver#ranges" format="html" scope="external">ranges</xref>.</entry>
+              <entry>Required plug-in version in
+                <xref keyref="semver"/> format that may contain
+                <xref href="https://docs.npmjs.com/misc/semver#ranges" format="html" scope="external"
+                >ranges</xref>.</entry>
             </row>
           </tbody>
         </tgroup>
       </table>
       <note>Version numbers in the <codeph>vers</codeph> and <codeph>req</codeph> keys use the three-digit format
-        specified by <xref keyref="semver"/>. An initial development release of a plug-in might start at version 0.1.0,
-        and an initial production release at 1.0.0. If your plug-in requires DITA-OT 3.1 or later, set the
-          <codeph>req</codeph> key to <codeph>&gt;=3.1.0</codeph>. Using the greater-than sign allows your plug-in to
-        work with compatible maintenance releases, such as 3.1.3. If the requirement is set to <codeph>=3.1.0</codeph>,
-        the registry will only offer it for installation on that exact version.</note>
+        specified by
+        <xref keyref="semver"/>. An initial development release of a plug-in might start at version 0.1.0, and an
+        initial production release at 1.0.0. If your plug-in requires DITA-OT 3.1 or later, set the <codeph>req</codeph>
+        key to <codeph>&gt;=3.1.0</codeph>. Using the greater-than sign allows your plug-in to work with compatible
+        maintenance releases, such as 3.1.3. If the requirement is set to <codeph>=3.1.0</codeph>, the registry will
+        only offer it for installation on that exact version.</note>
     </section>
     <section id="example-1">
       <title>Sample plug-in entry file</title>
-      <div outputclass="div-index">
-        <indexterm>DocBook</indexterm>
-      </div>
+      <indexterm>DocBook</indexterm>
       <p>The example below shows an entry for the <codeph>DocBook</codeph> plug-in. The complete file is available in
-        the registry as <xref href="https://github.com/dita-ot/registry/blob/master/org.dita.docbook.json" format="json"
+        the registry as
+        <xref href="https://github.com/dita-ot/registry/blob/master/org.dita.docbook.json" format="json"
           scope="external">org.dita.docbook.json</xref>.</p>
       <codeblock outputclass="language-json" xml:space="preserve">[
   {
@@ -228,8 +233,9 @@
     </section>
     <section id="adding-custom-registries">
       <title>Adding custom registries</title>
-      <p>In addition to the main plug-in registry at <xref keyref="site-plugin-registry"/>, you can create a registry of
-        your own to store the custom plug-ins for your company or organization.</p>
+      <p>In addition to the main plug-in registry at
+        <xref keyref="site-plugin-registry"/>, you can create a registry of your own to store the custom plug-ins for
+        your company or organization.</p>
       <p>A registry is just a directory that contains JSON files like the one above; each JSON file represents one entry
         in the registry. To add a custom registry location, edit the
           <filepath>config/configuration.properties</filepath> file in the DITA-OT installation directory and add the

--- a/topics/prerequisite-software.dita
+++ b/topics/prerequisite-software.dita
@@ -59,6 +59,7 @@
     </section>
     <section>
       <title>Software required for specific transformations</title>
+      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
       <div outputclass="div-index">
         <indexterm>locale</indexterm>
       </div>

--- a/topics/prerequisite-software.dita
+++ b/topics/prerequisite-software.dita
@@ -9,15 +9,25 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>RenderX<indexterm>XSL-FO processor</indexterm></indexterm>
-        <indexterm>Antenna House<indexterm>XSL-FO processor</indexterm></indexterm>
-        <indexterm>Apache FOP<indexterm>XSL-FO processor</indexterm></indexterm>
-        <indexterm>installing<indexterm>prerequisites</indexterm></indexterm>
-        <indexterm>XSLT<indexterm>processor</indexterm></indexterm>
-        <indexterm>XSLT<indexterm>2.0</indexterm></indexterm>
-        <indexterm>Saxon<indexterm>version</indexterm></indexterm>
-        <indexterm>Java<indexterm>Java Development Kit (JDK)</indexterm><indexterm>Java Runtime Environment (JRE)</indexterm></indexterm>
-        <indexterm>XSL-FO processor<index-see>Antenna House</index-see><index-see>RenderX</index-see><index-see>Apache FOP</index-see></indexterm>
+        <indexterm>RenderX
+          <indexterm>XSL-FO processor</indexterm></indexterm>
+        <indexterm>Antenna House
+          <indexterm>XSL-FO processor</indexterm></indexterm>
+        <indexterm>Apache FOP
+          <indexterm>XSL-FO processor</indexterm></indexterm>
+        <indexterm>installing
+          <indexterm>prerequisites</indexterm></indexterm>
+        <indexterm>XSLT
+          <indexterm>processor</indexterm></indexterm>
+        <indexterm>XSLT
+          <indexterm>2.0</indexterm></indexterm>
+        <indexterm>Saxon
+          <indexterm>version</indexterm></indexterm>
+        <indexterm>Java
+          <indexterm>Java Development Kit (JDK)</indexterm>
+          <indexterm>Java Runtime Environment (JRE)</indexterm></indexterm>
+        <indexterm>XSL-FO processor<index-see>Antenna House</index-see><index-see>RenderX</index-see><index-see>Apache
+            FOP</index-see></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/prerequisite-software.dita
+++ b/topics/prerequisite-software.dita
@@ -26,8 +26,10 @@
         <indexterm>Java
           <indexterm>Java Development Kit (JDK)</indexterm>
           <indexterm>Java Runtime Environment (JRE)</indexterm></indexterm>
-        <indexterm>XSL-FO processor<index-see>Antenna House</index-see><index-see>RenderX</index-see><index-see>Apache
-            FOP</index-see></indexterm>
+        <indexterm>XSL-FO processor
+          <index-see>Antenna House</index-see>
+          <index-see>RenderX</index-see>
+          <index-see>Apache FOP</index-see></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -47,22 +49,20 @@
           <dlentry id="antbuild">
             <dt>Apache Ant</dt>
             <dd>Provides the standard setup and sequencing of processing steps. DITA-OT includes Ant version <keyword
-                keyref="tool.ant.version"/>. You can download Ant from <xref keyref="download.ant"/>.</dd>
+                keyref="tool.ant.version"/>. You can download Ant from
+              <xref keyref="download.ant"/>.</dd>
           </dlentry>
           <dlentry>
             <dt>XSLT processor</dt>
             <dd>Provides the main transformation services. It must be compliant with XSLT 2.0. DITA-OT includes Saxon
-              version <keyword keyref="tool.saxon.version"/>. You can download Saxon from <xref keyref="download.saxon"
-              />.</dd>
+              version <keyword keyref="tool.saxon.version"/>. You can download Saxon from
+              <xref keyref="download.saxon"/>.</dd>
           </dlentry>
         </dl></p>
     </section>
     <section>
       <title>Software required for specific transformations</title>
-      <!-- Wrap index terms to permit post-processing workaround for https://github.com/dita-ot/dita-ot/issues/3042 -->
-      <div outputclass="div-index">
-        <indexterm>locale</indexterm>
-      </div>
+      <indexterm>locale</indexterm>
       <p>Depending on the type of output that you want to generate, you might need the following applications:
         <dl>
           <dlentry>
@@ -72,18 +72,19 @@
                 topics.</draft-comment>ICU for Java is a cross-platform, Unicode-based, globalization library. It
               includes support for comparing locale-sensitive strings; formatting dates, times, numbers, currencies, and
               messages; detecting text boundaries; and converting character sets. You can download ICU for Java from
-                <xref keyref="download.icu4j"/>.</dd>
+              <xref keyref="download.icu4j"/>.</dd>
           </dlentry>
           <dlentry>
             <dt>Microsoft Help Workshop</dt>
-            <dd>Required for generating HTML help. You can download the Help Workshop from <xref
-                keyref="download.html-help-workshop"/>.</dd>
+            <dd>Required for generating HTML help. You can download the Help Workshop from
+              <xref keyref="download.html-help-workshop"/>.</dd>
           </dlentry>
           <dlentry>
             <dt>XSL-FO processor</dt>
             <dd>Required for generating PDF output. <tm tmtype="tm">Apache</tm> FOP (Formatting Objects Processor) is
-              included in the distribution package. You can download other versions from <xref keyref="download.fop"/>.
-              You can also use commercial FO processors such as Antenna House Formatter or RenderX XEP.</dd>
+              included in the distribution package. You can download other versions from
+              <xref keyref="download.fop"/>. You can also use commercial FO processors such as Antenna House Formatter
+              or RenderX XEP.</dd>
           </dlentry>
         </dl></p>
     </section>

--- a/userguide-book.ditamap
+++ b/userguide-book.ditamap
@@ -49,6 +49,9 @@
     <appendix keyref="release-notes"/>
   </appendices>
   <backmatter>
+    <booklists>
+      <indexlist/>
+    </booklists>
     <mapref href="resources/common-resources.ditamap" processing-role="resource-only"/>
   </backmatter>
 </bookmap>


### PR DESCRIPTION
This PR builds on the indexing work done by @lief-erickson for #53 with PR #258:

- enables the index in PDF output for the 3.4 release
- places index entries on new lines to improve readability of multi-level entries
- removes workarounds for dita-ot/dita-ot#3042 after resolution in dita-ot/dita-ot#3381


