### PR TITLE
Promote “output formats” to top level of ToC

### DIFF
--- a/index.dita
+++ b/index.dita
@@ -17,7 +17,8 @@
   <body>
 
     <note>While the DITA standard is owned and developed by OASIS, the DITA Open Toolkit project is governed separately.
-      DITA-OT is an independent, open-source implementation of the DITA standard.</note>
+      DITA-OT is an independent, open-source implementation of the <xref keyref="dita13-spec">DITA
+      standard</xref>.</note>
 
     <section>
       <title>DITA-OT documentation</title>

--- a/index.dita
+++ b/index.dita
@@ -29,9 +29,11 @@
         <li>
           <xref keyref="installing-client"/> shows how to install the toolkit and run a build to verify the
           installation.</li>
+        <li><xref keyref="building-output"/> provides information about transforming content, and the available output
+          formats.</li>
         <li><xref keyref="alternative-input-formats"/> introduces the new input formats supported in DITA-OT ≥ 3.0.</li>
-        <li><xref keyref="building-output"/> provides information about transforming content, and the
-          available output formats.</li>
+        <li><xref keyref="output-formats">Output formats</xref> provides an overview of the default transformations that
+          generate output from DITA content.</li>
         <li><xref keyref="parameters"/> explains how to adjust the behavior of DITA Open Toolkit via
             <cmdname>dita</cmdname> command arguments and options, DITA-OT parameter settings, and configuration
           properties.</li>

--- a/index.dita
+++ b/index.dita
@@ -28,7 +28,7 @@
         <li>
           <xref keyref="installing-client"/> shows how to install the toolkit and run a build to verify the
           installation.</li>
-        <li><xref keyref="alternative-input-formats"/> introduces the new input formats supported in DITA-OT³.</li>
+        <li><xref keyref="alternative-input-formats"/> introduces the new input formats supported in DITA-OT 3.0.</li>
         <li><xref keyref="building-output"/> provides information about transforming content, and the
           available output formats.</li>
         <li><xref keyref="parameters"/> explains how to adjust the behavior of DITA Open Toolkit via

--- a/index.dita
+++ b/index.dita
@@ -28,7 +28,7 @@
         <li>
           <xref keyref="installing-client"/> shows how to install the toolkit and run a build to verify the
           installation.</li>
-        <li><xref keyref="alternative-input-formats"/> introduces the new input formats supported in DITA-OT 3.0.</li>
+        <li><xref keyref="alternative-input-formats"/> introduces the new input formats supported in DITA-OT ≥ 3.0.</li>
         <li><xref keyref="building-output"/> provides information about transforming content, and the
           available output formats.</li>
         <li><xref keyref="parameters"/> explains how to adjust the behavior of DITA Open Toolkit via

--- a/resources/common-toc.ditamap
+++ b/resources/common-toc.ditamap
@@ -10,11 +10,14 @@
   <topicref keyref="installing-client">
     <mapref href="../topics/installing.ditamap"/>
   </topicref>
+  <topicref keyref="building-output">
+    <mapref href="../topics/publishing.ditamap"/>
+  </topicref>
   <topicref keyref="alternative-input-formats" collection-type="family">
     <mapref href="../topics/input-formats.ditamap"/>
   </topicref>
-  <topicref keyref="building-output">
-    <mapref href="../topics/publishing.ditamap"/>
+  <topicref keyref="output-formats">
+    <mapref href="../topics/transformations.ditamap"/>
   </topicref>
   <topicref keyref="parameters">
     <mapref href="../parameters/parameters.ditamap"/>

--- a/topics/alternative-input-formats.dita
+++ b/topics/alternative-input-formats.dita
@@ -7,7 +7,7 @@
   <titlealts>
     <navtitle>Authoring formats</navtitle>
   </titlealts>
-  <shortdesc>DITA-OT³ supports several alternative input formats in addition to standard DITA XML, including Markdown
+  <shortdesc>DITA-OT supports several alternative input formats in addition to standard DITA XML, including Markdown
     and the proposed XDITA, MDITA and HDITA authoring formats currently in development for Lightweight DITA.</shortdesc>
   <prolog>
     <metadata>

--- a/topics/alternative-input-formats.dita
+++ b/topics/alternative-input-formats.dita
@@ -7,8 +7,9 @@
   <titlealts>
     <navtitle>Authoring formats</navtitle>
   </titlealts>
-  <shortdesc>DITA-OT supports several alternative input formats in addition to standard DITA XML, including Markdown
-    and the proposed XDITA, MDITA and HDITA authoring formats currently in development for Lightweight DITA.</shortdesc>
+  <shortdesc>DITA-OT supports several alternative input formats in addition to <xref keyref="dita13-spec">standard DITA
+      XML</xref>, including Markdown and the proposed XDITA, MDITA and HDITA authoring formats currently in development
+    for Lightweight DITA.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/topics/publishing.ditamap
+++ b/topics/publishing.ditamap
@@ -26,7 +26,5 @@
   </topicref>
   <topicref keyref="java-api"/>
 
-  <mapref href="transformations.ditamap"/>
-
   <mapref href="publishing-reltables.ditamap"/>
 </map>

--- a/topics/transformations.ditamap
+++ b/topics/transformations.ditamap
@@ -4,15 +4,15 @@
 
 <map>
   <title>DITA-OT transformations</title>
-  <topicref keyref="output-formats">
-    <topicref keyref="dita2pdf"/>
-    <topicref keyref="dita2html5"/>
-    <topicref keyref="dita2eclipsehelp"/>
-    <topicref keyref="dita2htmlhelp" platform="windows"/>
-    <topicref keyref="dita2markdown"/>
-    <topicref keyref="dita2dita"/>
-    <topicref keyref="dita2tocjs"/>
-    <topicref keyref="dita2troff"/>
-    <topicref keyref="dita2xhtml"/>
-  </topicref>
+
+  <topicref keyref="dita2pdf"/>
+  <topicref keyref="dita2html5"/>
+  <topicref keyref="dita2eclipsehelp"/>
+  <topicref keyref="dita2htmlhelp" platform="windows"/>
+  <topicref keyref="dita2markdown"/>
+  <topicref keyref="dita2dita"/>
+  <topicref keyref="dita2tocjs"/>
+  <topicref keyref="dita2troff"/>
+  <topicref keyref="dita2xhtml"/>
+
 </map>

--- a/userguide-book.ditamap
+++ b/userguide-book.ditamap
@@ -20,11 +20,14 @@
   <part keyref="installing-client">
     <chapter format="ditamap" href="topics/installing.ditamap"/>
   </part>
+  <part keyref="building-output">
+    <chapter href="topics/publishing.ditamap" format="ditamap"/>
+  </part>
   <part keyref="alternative-input-formats">
     <chapter href="topics/input-formats.ditamap" format="ditamap"/>
   </part>
-  <part keyref="building-output">
-    <chapter href="topics/publishing.ditamap" format="ditamap"/>
+  <part keyref="output-formats">
+    <chapter href="topics/transformations.ditamap" format="ditamap"/>
   </part>
   <part keyref="parameters">
     <chapter href="parameters/parameters.ditamap" format="ditamap"/>


### PR DESCRIPTION
The [output formats](https://www.dita-ot.org/dev/topics/output-formats.html) section has been buried under [Building output](https://www.dita-ot.org/dev/topics/building-output.html), but as a transformation tool, it seems like this deserves a more prominent location in the table of contents.
