### PR TITLE
Remove index range markup

### DIFF
--- a/parameters/ant-parameters-details.dita
+++ b/parameters/ant-parameters-details.dita
@@ -32,7 +32,7 @@
                   <parmname>args.draft</parmname> parameter to <option>yes</option> causes the contents of the
                   <xmlelement>titlealts</xmlelement> element to be rendered below the title.
                 <indexterm><xmlelement>titlealts</xmlelement></indexterm>
-                <indexterm start="ant-xslt-params">XSLT</indexterm>
+                <indexterm>XSLT</indexterm>
                 <indexterm>draft
                   <indexterm>args.draft</indexterm>
                   <indexterm>PDF</indexterm></indexterm>
@@ -668,8 +668,7 @@
             <pd conaction="pushafter">The default value is the value of the <parmname>args.draft</parmname> parameter.
                 <ph audience="xslt-customizer">Corresponds to the XSLT parameter
                   <parmname>publishRequiredCleanup</parmname>.</ph><note type="notice">This parameter is deprecated in
-                favor of the <parmname>args.draft</parmname> parameter.
-                <indexterm end="ant-xslt-params"/></note></pd>
+                favor of the <parmname>args.draft</parmname> parameter.</note></pd>
           </plentry>
         </parml>
       </section>

--- a/reference/preprocess-copyfiles.dita
+++ b/reference/preprocess-copyfiles.dita
@@ -14,7 +14,6 @@
         <indexterm>preprocessing<indexterm><codeph>copy-files</codeph></indexterm></indexterm>
         <indexterm><codeph>copy-files</codeph></indexterm>
         <indexterm>images<indexterm>copying</indexterm></indexterm>
-        <indexterm end="preprocessing"/>
       </keywords>
     </metadata>
   </prolog>

--- a/reference/preprocessing.dita
+++ b/reference/preprocessing.dita
@@ -10,7 +10,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>preprocessing<indexterm  start="preprocessing">modules</indexterm></indexterm>
+        <indexterm>preprocessing<indexterm>modules</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/DITA-messages-details.xml
+++ b/topics/DITA-messages-details.xml
@@ -509,7 +509,7 @@
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX020E-extra" conaction="pushreplace">DITA-OT is only able to
           dynamically retrieve titles when the target is a local (not peer or external) DITA resource.
-        <indexterm start="navtitle">navtitle</indexterm>
+        <indexterm>navtitle</indexterm>
         </stentry>
       </strow>
       <strow>
@@ -533,8 +533,7 @@
       </strow>
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX025E-extra" conaction="pushreplace">DITA-OT is only able to
-          dynamically retrieve titles when the target is a local DITA resource.
-        <indexterm end="navtitle"/></stentry>
+          dynamically retrieve titles when the target is a local DITA resource.</stentry>
       </strow>
       <strow>
         <stentry conref="DITA-messages.xml#msgs/DOTX026W-extra" conaction="pushreplace">The referenc to this document

--- a/topics/alternative-input-formats.dita
+++ b/topics/alternative-input-formats.dita
@@ -12,7 +12,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm start="lwdita">Lightweight DITA</indexterm> <!-- https://github.com/dita-ot/dita-ot/issues/3318 -->
+        <indexterm>Lightweight DITA</indexterm>
         <indexterm>LwDITA<index-see>Lightweight DITA</index-see></indexterm>
         <indexterm>MDITA<index-see>Lightweight DITA</index-see></indexterm>
         <indexterm>XDITA<index-see>Lightweight DITA</index-see></indexterm>

--- a/topics/custom-plugins.dita
+++ b/topics/custom-plugins.dita
@@ -10,7 +10,7 @@
     <metadata>
       <keywords>
         <indexterm>DITA<indexterm>specializations</indexterm></indexterm>
-        <indexterm start="plugins">plug-ins</indexterm>
+        <indexterm>plug-ins</indexterm>
         <indexterm>plug-ins<indexterm>benefits</indexterm></indexterm>
         <indexterm>plug-ins<indexterm>working with</indexterm></indexterm>
       </keywords>

--- a/topics/html-customization-plugin-javascript.dita
+++ b/topics/html-customization-plugin-javascript.dita
@@ -15,7 +15,6 @@
         <indexterm><xmlelement>footer</xmlelement></indexterm>
         <indexterm><xmlelement>require</xmlelement></indexterm>
         <indexterm><xmlelement>head</xmlelement></indexterm>
-        <indexterm>transformations<indexterm end="html"/></indexterm> <!-- LE: This range is not appearing in the FOP index. -->
         <indexterm>HTML5<indexterm>JavaScript, adding</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/html-customization.dita
+++ b/topics/html-customization.dita
@@ -13,7 +13,7 @@
     <metadata>
       <keywords>
         <indexterm>HTML<indexterm>customizing</indexterm></indexterm>
-        <indexterm>transformations<indexterm start="html">HTML</indexterm></indexterm>
+        <indexterm>transformations<indexterm>HTML</indexterm></indexterm>
         <indexterm>plug-ins<indexterm>HTML5</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/implement-saxon-collation-uri-resolvers.dita
+++ b/topics/implement-saxon-collation-uri-resolvers.dita
@@ -16,8 +16,6 @@
         <indexterm><xmlatt>xsl:sort</xmlatt></indexterm>
         <indexterm>Chinese</indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm end="plugin-ideas"/></indexterm>
-        <indexterm>plug-ins<indexterm end="plugins-saxon"/></indexterm>
         <indexterm>XSLT<indexterm>URI resolver</indexterm></indexterm>
       </keywords>
     </metadata>

--- a/topics/implement-saxon-customizations.dita
+++ b/topics/implement-saxon-customizations.dita
@@ -17,7 +17,7 @@
         <indexterm>Saxon<index-see-also>Ant</index-see-also></indexterm>
         <indexterm>Ant<index-see-also>Saxon</index-see-also></indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>plug-ins<indexterm start="plugins-saxon">Saxon</indexterm></indexterm>
+        <indexterm>plug-ins<indexterm>Saxon</indexterm></indexterm>
         <indexterm>XSLT<indexterm>Saxon</indexterm></indexterm>
         <indexterm>preprocessing<indexterm>extension points, Saxon</indexterm></indexterm>
         <indexterm>Java<indexterm>ServiceLoader</indexterm></indexterm>

--- a/topics/markdown-dita-syntax-reference.dita
+++ b/topics/markdown-dita-syntax-reference.dita
@@ -13,7 +13,6 @@
     <metadata>
       <keywords>
         <indexterm>Pandoc</indexterm>
-        <indexterm end="lwdita"/>
         <indexterm>UTF</indexterm>
         <indexterm>DITA
           <indexterm>specializations</indexterm></indexterm>

--- a/topics/migrating-to-1.5.4.dita
+++ b/topics/migrating-to-1.5.4.dita
@@ -30,7 +30,6 @@
         <indexterm>Russian</indexterm>
         <indexterm>Swedish</indexterm>
         <indexterm>I18N<indexterm><parmname>org.dita.pdf2.i18n.enabled</parmname></indexterm></indexterm>
-        <indexterm end="migrate"/>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/migration.dita
+++ b/topics/migration.dita
@@ -13,9 +13,7 @@
         <indexterm>upgrading<indexterm>plug-ins</indexterm></indexterm>
         <!-- LE: Only first alphabetical index-see-also prints in the index -->
         <indexterm>upgrading<index-see-also>migrating</index-see-also><index-see-also>installing</index-see-also></indexterm>
-        <indexterm>migrating</indexterm> <!-- LE: Build crash for the line above if this line does not exist even though
-        the line below does. Its existence causes duplicate page number to be emitted. Also, the line below does not generate a range. The @end is in migrating-to-1.5.4.dita. -->
-        <indexterm start="migrate">migrating</indexterm>
+        <indexterm>migrating</indexterm>
         <indexterm>plug-ins<indexterm>upgrading</indexterm></indexterm>
         <indexterm>installing</indexterm>
       </keywords>

--- a/topics/pdf-customization.dita
+++ b/topics/pdf-customization.dita
@@ -13,7 +13,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>transformations<indexterm start="pdf">PDF</indexterm></indexterm> <!-- LE: This is not generating a page range. -->
+        <indexterm>transformations<indexterm>PDF</indexterm></indexterm>
         <indexterm>PDF</indexterm>
       </keywords>
     </metadata>

--- a/topics/pdf-plugin-structure.dita
+++ b/topics/pdf-plugin-structure.dita
@@ -11,7 +11,7 @@
       <keywords>
         <indexterm>languages<indexterm>adding support for</indexterm></indexterm>
         <indexterm>I18N<indexterm>plug-in</indexterm></indexterm>
-        <indexterm>PDF<indexterm start="pdf-plugin">plug-in</indexterm></indexterm>
+        <indexterm>PDF<indexterm>plug-in</indexterm></indexterm>
         <indexterm>font-mappings.xml</indexterm>
         <indexterm>fonts<indexterm>PDF</indexterm></indexterm>
         <indexterm>PDF<indexterm>fonts</indexterm></indexterm>

--- a/topics/pdf-plugin-structure_fo-xsl.dita
+++ b/topics/pdf-plugin-structure_fo-xsl.dita
@@ -9,7 +9,7 @@
     <prolog>
         <metadata>
             <keywords>
-                <indexterm end="pdf-plugin"/>
+                <indexterm/>
             </keywords>
         </metadata>
     </prolog>

--- a/topics/pdf2-creating-change-bars.dita
+++ b/topics/pdf2-creating-change-bars.dita
@@ -18,7 +18,7 @@
         <indexterm>Antenna House<indexterm>change bars</indexterm></indexterm>
         <indexterm>Apache FOP<indexterm>change bars</indexterm></indexterm>
         <indexterm>PDF<indexterm>change bars</indexterm></indexterm>
-        <indexterm>transformations<indexterm end="pdf"/></indexterm>
+        <indexterm>transformations</indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/plugin-applications.dita
+++ b/topics/plugin-applications.dita
@@ -9,7 +9,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>plug-ins<indexterm start="plugin-ideas">ideas for</indexterm></indexterm>
+        <indexterm>plug-ins<indexterm>ideas for</indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>

--- a/topics/plugin-coding-conventions.dita
+++ b/topics/plugin-coding-conventions.dita
@@ -13,7 +13,6 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm end="plugins"/>
         <indexterm>plug-ins
           <indexterm>best practices</indexterm></indexterm>
         <indexterm>XSLT


### PR DESCRIPTION
Due to a misunderstanding of how index ranges are designed the markup has been removed by deleting the `@end` entry and retaining the content of `@start`. [#3318 ](https://github.com/dita-ot/dita-ot/issues/3318) 

Signed-off-by: Lief Erickson <lief.erickson@scriptorium.com>