### PR TITLE
Update Gradle wrapper to 5.6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle distribution version & regenerate wrapper to pick up recent changes per
https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper

    ./gradlew wrapper --gradle-version 5.6.2

Signed-off-by: Roger Sheen <roger@infotexture.net>

## How Has This Been Tested?

- [x] Updated wrapper in docs repo, verified builds with [eerohele/dita-ot-gradle](https://github.com/eerohele/dita-ot-gradle) 0.5.0 ✅ 
- [x] Ran core `dist` build task on a fresh worktree with Gradle wrapper 5.6.2, build successful ✅ 
