### PR TITLE
Missing 'repo' scope for access token

### DIFF
--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -66,12 +66,13 @@
         <cmd>Log in to the GitHub Package Registry.</cmd>
         <substeps>
           <substep>
-            <cmd>In your
-              <xref href="https://github.com/settings/tokens" format="html" scope="external">GitHub profile
-                settings</xref>, create a new personal access token with the <codeph>read:packages</codeph> scope.</cmd>
-            <info>For more information, see
-              <xref href="https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line"
-                scope="external" format="html">Creating a personal access token for the command line</xref>.</info>
+            <cmd>In your <xref href="https://github.com/settings/tokens" format="html"
+                scope="external">GitHub profile settings</xref>, create a new personal access token
+              with the <codeph>read:packages</codeph> and <codeph>repo</codeph> scopes.</cmd>
+            <info>For more information, see <xref
+                href="https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line"
+                scope="external" format="html">Creating a personal access token for the command
+                line</xref>.</info>
           </substep>
           <substep>
             <cmd>On the command line, run the <cmdname>docker</cmdname> command to log in with your GitHub


### PR DESCRIPTION
---
name: Pull request
about: Docker image instructions
---

## Description
This adds the `repo` scope to the instructions around creating a GitHub access token. The token needs both `repo` and `read:packages` scopes, or you'll get the following error when you try to do anything with the container (pull, build etc.): 
"Your token has not been granted the required scopes to execute this query. The 'name' field requires one of the following scopes: ['repo'], but your token has only been granted the: ['read:packages'] scopes."