### PR TITLE
Output platform profile attributes in website build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ task site(type: DitaOtTask) {
 
     input file("${projectDir}/site.ditamap")
     output getPropertyOrDefault('outputDir', "${buildDir}/site")
-    filter "${projectDir}/resources/html.ditaval"
+    filter "${projectDir}/resources/site.ditaval"
 
     transtype 'org.dita-ot.html'
 

--- a/resources/site.ditaval
+++ b/resources/site.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="deliveryTarget" val="html" />
+  <prop action="exclude" att="deliveryTarget" val="pdf" />
+  <prop action="passthrough" att="platform"/>
+</val>


### PR DESCRIPTION
## Description
In dita-ot.org build, output `@platform` attribute into HTML5 `data-platform` attribute.

## Motivation and Context
When platform information is retained in HTML5 output, the data can be used for dynamic filtering.

