### PR TITLE
Add platform profiling

### DIFF
--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -369,11 +369,11 @@
           <pd>Convert partial documentation sets by processing input with additional resources.
             <p>For example, to process a single topic file with a map that contains key definitions, use a command like
               this:
-              <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>topic.dita</filepath> <parmname>--resource</parmname>=<filepath>keys.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+              <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>topic.dita</filepath> <parmname>--resource</parmname>=<filepath>keys.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
             </p>
             <p>To convert a chapter map to HTML5 and insert related links from relationship tables in a separate map,
               use:
-              <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>chapter.ditamap</filepath> <parmname>--resource</parmname>=<filepath>reltables.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+              <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>chapter.ditamap</filepath> <parmname>--resource</parmname>=<filepath>reltables.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
             </p></pd>
         </plentry>
         <plentry>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -369,11 +369,11 @@
           <pd>Convert partial documentation sets by processing input with additional resources.
             <p>For example, to process a single topic file with a map that contains key definitions, use a command like
               this:
-              <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>topic.dita</filepath> <parmname>--resource</parmname>=<filepath>keys.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+              <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>topic.dita</filepath> <parmname>--resource</parmname>=<filepath>keys.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
             </p>
             <p>To convert a chapter map to HTML5 and insert related links from relationship tables in a separate map,
               use:
-              <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>chapter.ditamap</filepath> <parmname>--resource</parmname>=<filepath>reltables.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+              <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>chapter.ditamap</filepath> <parmname>--resource</parmname>=<filepath>reltables.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
             </p></pd>
         </plentry>
         <plentry>

--- a/resources/subjectscheme-outputclass.ditamap
+++ b/resources/subjectscheme-outputclass.ditamap
@@ -89,6 +89,14 @@
     <subjectdef keys="preprocess"/>
   </subjectdef>
 
+  <subjectdef keyref="filepath-outputclass">
+    <topicmeta>
+      <navtitle>Filepath</navtitle>
+      <shortdesc>Control multi-platform processing</shortdesc>
+    </topicmeta>
+    <subjectdef keys="preserve-separator"/>
+  </subjectdef>
+
   <subjectdef keys="title-outputclass">
     <topicmeta>
       <navtitle>Titles</navtitle>
@@ -110,6 +118,11 @@
     <attributedef name="outputclass"/>
     <subjectdef keyref="codeph-outputclass"/>
     <subjectdef keyref="codeblock-syntax"/>
+  </enumerationdef>
+  <enumerationdef>
+    <elementdef name="filepath"/>
+    <attributedef name="outputclass"/>
+    <subjectdef keyref="filepath-outputclass"/>
   </enumerationdef>
   <enumerationdef>
     <elementdef name="ph"/>

--- a/resources/subjectscheme-outputclass.ditamap
+++ b/resources/subjectscheme-outputclass.ditamap
@@ -66,6 +66,14 @@
       <subjectdef keys="language-xml"/>
       <subjectdef keys="language-yaml"/>
     </subjectdef>
+    <subjectdef keys="codeblock-syntax">
+      <topicmeta>
+        <navtitle>Code language</navtitle>
+        <shortdesc>Used to define the programming language code in codeblocks.</shortdesc>
+      </topicmeta>
+      <subjectdef keys="syntax-bash"/>
+      <subjectdef keys="syntax-batch"/>
+    </subjectdef>
   </subjectdef>
 
   <subjectdef keys="codeph-outputclass">
@@ -95,11 +103,13 @@
     <attributedef name="outputclass"/>
     <subjectdef keyref="codeblock-dita-ot-extensions"/>
     <subjectdef keyref="codeblock-syntax-highlights"/>
+    <subjectdef keyref="codeblock-syntax"/>
   </enumerationdef>
   <enumerationdef>
     <elementdef name="codeph"/>
     <attributedef name="outputclass"/>
     <subjectdef keyref="codeph-outputclass"/>
+    <subjectdef keyref="codeblock-syntax"/>
   </enumerationdef>
   <enumerationdef>
     <elementdef name="ph"/>

--- a/topics/building-with-ant.dita
+++ b/topics/building-with-ant.dita
@@ -27,7 +27,7 @@
       </step>
       <step>
         <cmd>Issue the following command:</cmd>
-        <choicetable frame="topbot" relcolwidth="1* 3*">
+        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
           <chrow platform="linux mac">
             <choption>Linux or macOS&#xA0;</choption>
             <chdesc>

--- a/topics/creating-docker-images.dita
+++ b/topics/creating-docker-images.dita
@@ -60,7 +60,7 @@
       <title>Building a new image</title>
       <p>You can build a Docker image from this example by running the following command from the <filepath
           conkeyref="conref-task/samples-dir"/> directory:</p>
-      <codeblock>$ <cmdname>docker</cmdname> image build -t sample-docker-image:1.0 .
+      <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> image build -t sample-docker-image:1.0 .
 Sending build context to Docker daemon  2.048kB
 Step 1/3 : FROM docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/>
  ---> 9abb96827538
@@ -83,7 +83,7 @@ Successfully tagged sample-docker-image:1.0
     <example>
       <title>Running the new container</title>
       <p>You can then start a container based on your new image:</p>
-      <codeblock>$ <cmdname>docker</cmdname> container run -it \
+      <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> container run -it \
   -v /path/to/dita-ot-dir/docsrc:/src sample-docker-image:1.0 \
   -i /src/userguide.ditamap \
   -o /src/out/dita-bootstrap \

--- a/topics/creating-docker-images.dita
+++ b/topics/creating-docker-images.dita
@@ -60,7 +60,7 @@
       <title>Building a new image</title>
       <p>You can build a Docker image from this example by running the following command from the <filepath
           conkeyref="conref-task/samples-dir"/> directory:</p>
-      <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> image build -t sample-docker-image:1.0 .
+      <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> image build -t sample-docker-image:1.0 .
 Sending build context to Docker daemon  2.048kB
 Step 1/3 : FROM docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/>
  ---> 9abb96827538
@@ -83,7 +83,7 @@ Successfully tagged sample-docker-image:1.0
     <example>
       <title>Running the new container</title>
       <p>You can then start a container based on your new image:</p>
-      <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> container run -it \
+      <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> container run -it \
   -v /path/to/dita-ot-dir/docsrc:/src sample-docker-image:1.0 \
   -i /src/userguide.ditamap \
   -o /src/out/dita-bootstrap \

--- a/topics/determining-version-of-ditaot.dita
+++ b/topics/determining-version-of-ditaot.dita
@@ -31,7 +31,7 @@
       </step>
       <step>
         <cmd>Issue the following command:</cmd>
-        <choicetable frame="topbot" relcolwidth="1* 3*">
+        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
           <chrow platform="linux mac">
             <choption>Linux or macOS&#xA0;</choption>
             <chdesc>

--- a/topics/dita-command-help.dita
+++ b/topics/dita-command-help.dita
@@ -32,7 +32,7 @@
       </step>
       <step>
         <cmd>Issue the following command:</cmd>
-        <choicetable frame="topbot" relcolwidth="1* 3*">
+        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
           <chrow platform="linux mac">
             <choption>Linux or macOS&#xA0;</choption>
             <chdesc>

--- a/topics/html-customization-properties-file.dita
+++ b/topics/html-customization-properties-file.dita
@@ -47,7 +47,7 @@
         <cmd>Reference your <filepath>.properties</filepath> file with the <cmdname>dita</cmdname> command when building
           your output.</cmd>
         <stepxmp>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
         </stepxmp>
         <info/>
       </step>

--- a/topics/html-customization-properties-file.dita
+++ b/topics/html-customization-properties-file.dita
@@ -47,7 +47,7 @@
         <cmd>Reference your <filepath>.properties</filepath> file with the <cmdname>dita</cmdname> command when building
           your output.</cmd>
         <stepxmp>
-          <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
         </stepxmp>
         <info/>
       </step>

--- a/topics/increasing-the-jvm.dita
+++ b/topics/increasing-the-jvm.dita
@@ -40,12 +40,12 @@
     <steps-unordered>
       <step>
         <cmd>To change the value for a specific session, from the command prompt, issue the following command:</cmd>
-        <choicetable>
+        <choicetable outputclass="multi-platform">
           <chhead>
             <choptionhd>Platform</choptionhd>
             <chdeschd>Command</chdeschd>
           </chhead>
-          <chrow platform="linux mac" outputclass="multi-platform">
+          <chrow platform="unix">
             <choption>Linux or macOS&#xA0;</choption>
             <chdesc><codeph>export ANT_OPTS=$ANT_OPTS -Xmx<varname>1024</varname>M</codeph></chdesc>
           </chrow>

--- a/topics/increasing-the-jvm.dita
+++ b/topics/increasing-the-jvm.dita
@@ -45,7 +45,7 @@
             <choptionhd>Platform</choptionhd>
             <chdeschd>Command</chdeschd>
           </chhead>
-          <chrow platform="unix">
+          <chrow platform="linux mac" outputclass="multi-platform">
             <choption>Linux or macOS&#xA0;</choption>
             <chdesc><codeph>export ANT_OPTS=$ANT_OPTS -Xmx<varname>1024</varname>M</codeph></chdesc>
           </chrow>

--- a/topics/installing-via-homebrew.dita
+++ b/topics/installing-via-homebrew.dita
@@ -32,14 +32,14 @@
     <steps>
       <step>
         <cmd>Update Homebrew to make sure the latest package formulas are available on your system:</cmd>
-        <stepxmp><codeblock>$ <cmdname>brew update</cmdname>
+        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew update</cmdname>
 Already up-to-date.</codeblock></stepxmp>
         <stepresult>
           <p>Homebrew responds with a list of any new or updated formulæ.</p></stepresult>
       </step>
       <step importance="optional">
         <cmd>Check the version of DITA-OT that is available from Homebrew:</cmd>
-        <stepxmp><codeblock>$ <cmdname>brew info dita-ot</cmdname>
+        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew info dita-ot</cmdname>
 <systemoutput>dita-ot: stable <keyword keyref="maintenance-version"/>
 DITA Open Toolkit is an implementation of the OASIS DITA specification
 https://www.dita-ot.org/
@@ -54,7 +54,7 @@ Required: java >= 1.8 ✔</systemoutput>
       </step>
       <step>
         <cmd>Install the <codeph>dita-ot</codeph> package:</cmd>
-        <stepxmp><codeblock>$ <cmdname>brew install dita-ot</cmdname>
+        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew install dita-ot</cmdname>
 <systemoutput>Downloading…</systemoutput></codeblock></stepxmp>
         <stepresult>
           <p>Homebrew will automatically download the latest version of the toolkit, install it in a subfolder of the
@@ -63,14 +63,14 @@ Required: java >= 1.8 ✔</systemoutput>
       </step>
       <step importance="optional">
         <cmd>Verify the installation:</cmd>
-        <stepxmp><codeblock>$ <cmdname>which dita</cmdname>
+        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>which dita</cmdname>
 <systemoutput>/usr/local/bin/dita</systemoutput></codeblock></stepxmp>
         <stepresult>
           <p>The response confirms that the system will use the Homebrew-installed version of DITA-OT.</p></stepresult>
       </step>
       <step importance="optional">
         <cmd>Check the DITA-OT version number:</cmd>
-        <stepxmp><codeblock>$ <cmdname>dita</cmdname> <parmname>--version</parmname>
+        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>dita</cmdname> <parmname>--version</parmname>
 <systemoutput>DITA-OT version <keyword keyref="maintenance-version"/></systemoutput></codeblock></stepxmp>
         <stepresult>The DITA-OT version number appears on the console.</stepresult>
       </step>

--- a/topics/installing-via-homebrew.dita
+++ b/topics/installing-via-homebrew.dita
@@ -32,14 +32,14 @@
     <steps>
       <step>
         <cmd>Update Homebrew to make sure the latest package formulas are available on your system:</cmd>
-        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew update</cmdname>
+        <stepxmp><codeblock outputclass="syntax-bash">$ <cmdname>brew update</cmdname>
 Already up-to-date.</codeblock></stepxmp>
         <stepresult>
           <p>Homebrew responds with a list of any new or updated formulæ.</p></stepresult>
       </step>
       <step importance="optional">
         <cmd>Check the version of DITA-OT that is available from Homebrew:</cmd>
-        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew info dita-ot</cmdname>
+        <stepxmp><codeblock outputclass="syntax-bash">$ <cmdname>brew info dita-ot</cmdname>
 <systemoutput>dita-ot: stable <keyword keyref="maintenance-version"/>
 DITA Open Toolkit is an implementation of the OASIS DITA specification
 https://www.dita-ot.org/
@@ -54,7 +54,7 @@ Required: java >= 1.8 ✔</systemoutput>
       </step>
       <step>
         <cmd>Install the <codeph>dita-ot</codeph> package:</cmd>
-        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>brew install dita-ot</cmdname>
+        <stepxmp><codeblock outputclass="syntax-bash">$ <cmdname>brew install dita-ot</cmdname>
 <systemoutput>Downloading…</systemoutput></codeblock></stepxmp>
         <stepresult>
           <p>Homebrew will automatically download the latest version of the toolkit, install it in a subfolder of the
@@ -63,14 +63,14 @@ Required: java >= 1.8 ✔</systemoutput>
       </step>
       <step importance="optional">
         <cmd>Verify the installation:</cmd>
-        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>which dita</cmdname>
+        <stepxmp><codeblock outputclass="syntax-bash">$ <cmdname>which dita</cmdname>
 <systemoutput>/usr/local/bin/dita</systemoutput></codeblock></stepxmp>
         <stepresult>
           <p>The response confirms that the system will use the Homebrew-installed version of DITA-OT.</p></stepresult>
       </step>
       <step importance="optional">
         <cmd>Check the DITA-OT version number:</cmd>
-        <stepxmp><codeblock outputclass="language-bash">$ <cmdname>dita</cmdname> <parmname>--version</parmname>
+        <stepxmp><codeblock outputclass="syntax-bash">$ <cmdname>dita</cmdname> <parmname>--version</parmname>
 <systemoutput>DITA-OT version <keyword keyref="maintenance-version"/></systemoutput></codeblock></stepxmp>
         <stepresult>The DITA-OT version number appears on the console.</stepresult>
       </step>

--- a/topics/logging.dita
+++ b/topics/logging.dita
@@ -79,7 +79,7 @@
             <p>To use a custom Ant logger with the <cmdname>dita</cmdname> command, add the logger to the
                 <codeph>ANT_ARGS</codeph> environment variable by calling the following command before calling the
                 <cmdname>dita</cmdname> command:</p>
-            <codeblock>export ANT_ARGS="-logger org.apache.tools.ant.listener.AnsiColorLogger"</codeblock>
+            <codeblock outputclass="language-bash">export ANT_ARGS="-logger org.apache.tools.ant.listener.AnsiColorLogger"</codeblock>
             <p>Now you will get colorized messages when the <cmdname>dita</cmdname> command runs.</p>
             <note type="tip">Environment variables can also be set permanently. See
               <xref href="https://www.java.com/en/download/help/path.xml" format="html" scope="external">How do I set or
@@ -94,7 +94,7 @@
             <p>If you prefer to launch DITA-OT directly from Ant, you can also add the logger to the
                 <codeph>ANT_ARGS</codeph> environment variable, as explained above. You can also set the logger with the
                 <codeph>-logger</codeph> parameter when calling Ant.</p>
-            <codeblock>ant -logger org.apache.tools.ant.listener.AnsiColorLogger</codeblock>
+            <codeblock outputclass="language-bash">ant -logger org.apache.tools.ant.listener.AnsiColorLogger</codeblock>
           </dd>
         </dlentry>
       </dl>

--- a/topics/logging.dita
+++ b/topics/logging.dita
@@ -79,7 +79,7 @@
             <p>To use a custom Ant logger with the <cmdname>dita</cmdname> command, add the logger to the
                 <codeph>ANT_ARGS</codeph> environment variable by calling the following command before calling the
                 <cmdname>dita</cmdname> command:</p>
-            <codeblock outputclass="language-bash">export ANT_ARGS="-logger org.apache.tools.ant.listener.AnsiColorLogger"</codeblock>
+            <codeblock outputclass="syntax-bash">export ANT_ARGS="-logger org.apache.tools.ant.listener.AnsiColorLogger"</codeblock>
             <p>Now you will get colorized messages when the <cmdname>dita</cmdname> command runs.</p>
             <note type="tip">Environment variables can also be set permanently. See
               <xref href="https://www.java.com/en/download/help/path.xml" format="html" scope="external">How do I set or
@@ -94,7 +94,7 @@
             <p>If you prefer to launch DITA-OT directly from Ant, you can also add the logger to the
                 <codeph>ANT_ARGS</codeph> environment variable, as explained above. You can also set the logger with the
                 <codeph>-logger</codeph> parameter when calling Ant.</p>
-            <codeblock outputclass="language-bash">ant -logger org.apache.tools.ant.listener.AnsiColorLogger</codeblock>
+            <codeblock outputclass="syntax-bash">ant -logger org.apache.tools.ant.listener.AnsiColorLogger</codeblock>
           </dd>
         </dlentry>
       </dl>

--- a/topics/migrating-to-3.4.dita
+++ b/topics/migrating-to-3.4.dita
@@ -91,7 +91,7 @@
       <note conkeyref="reusable-components/legacy-plugins-note"/>
       <p>To re-install the plug-in(s) from the plug-in registry at
         <xref keyref="site-plugin-registry"/>, run the following command(s):</p>
-      <codeblock><cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>com.sophos.tocjs</filepath>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>com.sophos.tocjs</filepath>
 <cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>org.dita.troff</filepath></codeblock>
     </section>
   </refbody>

--- a/topics/migrating-to-3.4.dita
+++ b/topics/migrating-to-3.4.dita
@@ -91,7 +91,7 @@
       <note conkeyref="reusable-components/legacy-plugins-note"/>
       <p>To re-install the plug-in(s) from the plug-in registry at
         <xref keyref="site-plugin-registry"/>, run the following command(s):</p>
-      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>com.sophos.tocjs</filepath>
+      <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>com.sophos.tocjs</filepath>
 <cmdname>dita</cmdname> <parmname>--install</parmname>=<filepath>org.dita.troff</filepath></codeblock>
     </section>
   </refbody>

--- a/topics/plugins-installing.dita
+++ b/topics/plugins-installing.dita
@@ -23,7 +23,7 @@
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
         <info>
-          <codeblock><cmdname>dita install</cmdname> <varname>&lt;plug-in&gt;</varname></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita install</cmdname> <varname>&lt;plug-in&gt;</varname></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/plug-in"/>

--- a/topics/plugins-installing.dita
+++ b/topics/plugins-installing.dita
@@ -23,7 +23,7 @@
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
         <info>
-          <codeblock outputclass="language-bash"><cmdname>dita install</cmdname> <varname>&lt;plug-in&gt;</varname></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita install</cmdname> <varname>&lt;plug-in&gt;</varname></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/plug-in"/>

--- a/topics/plugins-registry.dita
+++ b/topics/plugins-registry.dita
@@ -40,14 +40,14 @@
         <xref keyref="site-plugin-registry"/> and install new plug-ins by name and optional version.</p>
       <p>Search the registry for a plug-in and install it by providing the plug-in name to the <cmdname>dita</cmdname>
         command.</p>
-      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;</varname></codeblock>
+      <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;</varname></codeblock>
       <p>If the registry includes multiple versions of the same plug-in, you can specify the version to install as
         follows:</p>
-      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;@&lt;plugin-version&gt;</varname></codeblock>
+      <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;@&lt;plugin-version&gt;</varname></codeblock>
       <p>If the plug-in requires other plug-ins, those are also installed recursively.</p>
       <p>For example, to revert PDF output to the legacy PDF2 layout that was the default in DITA-OT before 2.5, install
         the <filepath>org.dita.pdf2.legacy</filepath> plug-in as follows:</p>
-      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=org.dita.pdf2.legacy</codeblock>
+      <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=org.dita.pdf2.legacy</codeblock>
       <p>If a matching plug-in cannot be found, an error message will appear. Possible reasons for failure include:</p>
       <ul>
         <li>A plug-in with the specified name was not found in the registry</li>

--- a/topics/plugins-registry.dita
+++ b/topics/plugins-registry.dita
@@ -40,14 +40,14 @@
         <xref keyref="site-plugin-registry"/> and install new plug-ins by name and optional version.</p>
       <p>Search the registry for a plug-in and install it by providing the plug-in name to the <cmdname>dita</cmdname>
         command.</p>
-      <codeblock><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;</varname></codeblock>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;</varname></codeblock>
       <p>If the registry includes multiple versions of the same plug-in, you can specify the version to install as
         follows:</p>
-      <codeblock><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;@&lt;plugin-version&gt;</varname></codeblock>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=<varname>&lt;plugin-name&gt;@&lt;plugin-version&gt;</varname></codeblock>
       <p>If the plug-in requires other plug-ins, those are also installed recursively.</p>
       <p>For example, to revert PDF output to the legacy PDF2 layout that was the default in DITA-OT before 2.5, install
         the <filepath>org.dita.pdf2.legacy</filepath> plug-in as follows:</p>
-      <codeblock><cmdname>dita</cmdname> <parmname>--install</parmname>=org.dita.pdf2.legacy</codeblock>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--install</parmname>=org.dita.pdf2.legacy</codeblock>
       <p>If a matching plug-in cannot be found, an error message will appear. Possible reasons for failure include:</p>
       <ul>
         <li>A plug-in with the specified name was not found in the registry</li>

--- a/topics/plugins-removing.dita
+++ b/topics/plugins-removing.dita
@@ -20,7 +20,7 @@
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
         <info>
-          <codeblock><cmdname>dita uninstall</cmdname> <varname>&lt;plug-in-id&gt;</varname></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita uninstall</cmdname> <varname>&lt;plug-in-id&gt;</varname></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/plug-in-id"/>

--- a/topics/plugins-removing.dita
+++ b/topics/plugins-removing.dita
@@ -20,7 +20,7 @@
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
         <info>
-          <codeblock outputclass="language-bash"><cmdname>dita uninstall</cmdname> <varname>&lt;plug-in-id&gt;</varname></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita uninstall</cmdname> <varname>&lt;plug-in-id&gt;</varname></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/plug-in-id"/>

--- a/topics/project-files-json.dita
+++ b/topics/project-files-json.dita
@@ -31,7 +31,7 @@
     </fig>
     <p>This file can be used to generate the HTML version of the DITA-OT documentation by running the following command
       from the <filepath>docsrc</filepath> folder of the DITA-OT installation directory:</p>
-    <codeblock><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>samples/project-files/html.json</varname></codeblock>
+    <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>samples/project-files/html.json</varname></codeblock>
     <p>The project file for HTML output imports the common <codeph>html</codeph> context from a shared project context
       defined in the <filepath conkeyref="conref-task/samples-dir"/><filepath>/project-files/common.json</filepath>
       file, which includes the input map file and the DITAVAL file used to filter the output.</p>

--- a/topics/project-files-json.dita
+++ b/topics/project-files-json.dita
@@ -31,7 +31,7 @@
     </fig>
     <p>This file can be used to generate the HTML version of the DITA-OT documentation by running the following command
       from the <filepath>docsrc</filepath> folder of the DITA-OT installation directory:</p>
-    <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>samples/project-files/html.json</varname></codeblock>
+    <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>samples/project-files/html.json</varname></codeblock>
     <p>The project file for HTML output imports the common <codeph>html</codeph> context from a shared project context
       defined in the <filepath conkeyref="conref-task/samples-dir"/><filepath>/project-files/common.json</filepath>
       file, which includes the input map file and the DITAVAL file used to filter the output.</p>

--- a/topics/using-dita-command.dita
+++ b/topics/using-dita-command.dita
@@ -36,7 +36,7 @@
       </step>
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
-        <info><codeblock outputclass="language-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
+        <info><codeblock outputclass="language-bash"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/novice-variables-1"

--- a/topics/using-dita-command.dita
+++ b/topics/using-dita-command.dita
@@ -24,7 +24,7 @@
     <context audience="novice">The DITA-OT client is a command-line tool with no graphical user interface. To verify
       that your installation works correctly, you can build output using the sample files included in the distribution
       package.</context>
-    <steps>
+    <steps outputclass="multi-platform">
       <step audience="novice">
         <cmd>Open a terminal window by typing the following in the search bar:</cmd>
         <info>
@@ -36,7 +36,7 @@
       </step>
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
-        <info><codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
+        <info><codeblock outputclass="language-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/novice-variables-1"
@@ -52,14 +52,14 @@
     <example audience="novice">
       <p>Run from <filepath conkeyref="conref-task/samples-dir"/>, the following command generates
         HTML5 output for the <filepath>sequence.ditamap</filepath> file:</p>
-      <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+      <codeblock outputclass="language-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
       <indexterm>DITA maps
         <indexterm><cmdname>dita</cmdname> command example</indexterm></indexterm>
     </example>
     <example audience="expert">
       <p>For example, from <filepath conkeyref="conref-task/samples-dir"/>, run:</p>
       <p>
-        <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option> \
+        <codeblock outputclass="language-bash multi-platform"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option> \
      <parmname>--output</parmname>=<filepath>output/sequence</filepath> \
      <parmname>--args.input.dir</parmname>=<filepath conkeyref="conref-task/samples-absolute"/> \
      <parmname>--propertyfile</parmname>=<filepath>properties/sequence-html5.properties</filepath></codeblock>

--- a/topics/using-dita-command.dita
+++ b/topics/using-dita-command.dita
@@ -36,7 +36,7 @@
       </step>
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
-        <info><codeblock outputclass="language-bash"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
+        <info><codeblock outputclass="syntax-bash"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
           <p>where:</p>
           <ul>
             <li conkeyref="conref-task/novice-variables-1"
@@ -52,14 +52,14 @@
     <example audience="novice">
       <p>Run from <filepath conkeyref="conref-task/samples-dir"/>, the following command generates
         HTML5 output for the <filepath>sequence.ditamap</filepath> file:</p>
-      <codeblock outputclass="language-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+      <codeblock outputclass="syntax-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
       <indexterm>DITA maps
         <indexterm><cmdname>dita</cmdname> command example</indexterm></indexterm>
     </example>
     <example audience="expert">
       <p>For example, from <filepath conkeyref="conref-task/samples-dir"/>, run:</p>
       <p>
-        <codeblock outputclass="language-bash multi-platform"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option> \
+        <codeblock outputclass="syntax-bash multi-platform"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option> \
      <parmname>--output</parmname>=<filepath>output/sequence</filepath> \
      <parmname>--args.input.dir</parmname>=<filepath conkeyref="conref-task/samples-absolute"/> \
      <parmname>--propertyfile</parmname>=<filepath>properties/sequence-html5.properties</filepath></codeblock>

--- a/topics/using-dita-properties-file.dita
+++ b/topics/using-dita-properties-file.dita
@@ -62,7 +62,7 @@
         <cmd>Reference your <filepath>.properties</filepath> file with the <cmdname>dita</cmdname> command when building
           your output.</cmd>
         <stepxmp>
-          <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
         </stepxmp>
         <info/>
       </step>
@@ -72,7 +72,7 @@
         <stepxmp>
           <p>For example, to build output once with <xmlelement>draft</xmlelement> and
               <xmlelement>required-cleanup</xmlelement> content:</p>
-          <codeblock><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname> \
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname> \
      <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
         </stepxmp>
         <info>

--- a/topics/using-dita-properties-file.dita
+++ b/topics/using-dita-properties-file.dita
@@ -62,7 +62,7 @@
         <cmd>Reference your <filepath>.properties</filepath> file with the <cmdname>dita</cmdname> command when building
           your output.</cmd>
         <stepxmp>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname></codeblock>
         </stepxmp>
         <info/>
       </step>
@@ -72,7 +72,7 @@
         <stepxmp>
           <p>For example, to build output once with <xmlelement>draft</xmlelement> and
               <xmlelement>required-cleanup</xmlelement> content:</p>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname> \
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<varname>my.ditamap</varname> <parmname>--format</parmname>=<option>html5</option> <parmname>--propertyfile</parmname>=<varname>my.properties</varname> \
      <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
         </stepxmp>
         <info>

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -99,7 +99,7 @@
           <p>This command sequence specifies the following options:
             <ul>
               <li><option>-v</option> mounts the <filepath>source</filepath> subfolder of your home directory and binds
-                it to the <filepath>/src</filepath> volume in the container</li>
+                it to the <filepath outputclass="preserve-separator">/src</filepath> volume in the container</li>
               <li><option>-i</option> specifies the <filepath>input.ditamap</filepath> file in your
                   <filepath>source</filepath> folder as the input map file</li>
               <li><option>-o</option> writes the output to <filepath>source/out</filepath></li>
@@ -119,7 +119,7 @@
         </stepxmp>
         <info>
           <note>The DITA-OT container image uses the <codeph>ENTRYPOINT</codeph> instruction to run the
-              <cmdname>dita</cmdname> command from the <filepath>/opt/app/bin/</filepath> directory of the container
+              <cmdname>dita</cmdname> command from the <filepath outputclass="preserve-separator">/opt/app/bin/</filepath> directory of the container
             automatically, so you there’s no need to include the <cmdname>dita</cmdname> command itself, only the
             arguments and options you need to publish your content.</note>
         </info>

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -55,11 +55,11 @@
           </choice>
           <choice platform="mac">On macOS, you can also install Docker Desktop via
             <xref keyref="homebrew"/>:
-            <codeblock outputclass="language-bash">$ <cmdname>brew</cmdname> cask install docker
+            <codeblock outputclass="syntax-bash">$ <cmdname>brew</cmdname> cask install docker
 <systemoutput>Downloading…</systemoutput></codeblock>
           </choice>
           <choice platform="linux">On Linux, install Docker Community Edition (CE) via your operating system’s package manager, for
-            example: <codeblock outputclass="language-bash">$ <cmdname>sudo</cmdname> apt-get install docker-ce</codeblock></choice>
+            example: <codeblock outputclass="syntax-bash">$ <cmdname>sudo</cmdname> apt-get install docker-ce</codeblock></choice>
         </choices>
       </step>
       <step>
@@ -78,7 +78,7 @@
             <cmd>On the command line, run the <cmdname>docker</cmdname> command to log in with your GitHub
               credentials.</cmd>
             <stepxmp>
-              <codeblock outputclass="language-bash"><cmdname>docker</cmdname> login docker.pkg.github.com -u <varname>USERNAME</varname> -p <varname>PASSWORD/TOKEN</varname></codeblock>
+              <codeblock outputclass="syntax-bash"><cmdname>docker</cmdname> login docker.pkg.github.com -u <varname>USERNAME</varname> -p <varname>PASSWORD/TOKEN</varname></codeblock>
             </stepxmp>
             <info>For more information, see
               <xref
@@ -91,7 +91,7 @@
         <cmd>To build output, map a host directory to a container volume and specify options for the
             <cmdname>dita</cmdname> command.</cmd>
         <stepxmp>
-          <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> run -it \
+          <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> run -it \
   -v /Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \
   -i /src/input.ditamap \
   -o /src/out \

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -110,10 +110,10 @@
           <div platform="windows">
             <p>On Windows, if your <filepath>Users</filepath> directory is on the <filepath>C:\</filepath> drive, use
               <filepath>/c/Users/…</filepath> to map the host directory:</p>
-            <codeblock outputclass="language-batch">C:\Users\username> <cmdname>docker</cmdname> run -it \
-  -v /c/Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \
-  -i /src/input.ditamap \
-  -o /src/out \
+            <codeblock>> C:\Users\username> <cmdname>docker</cmdname> run -it ^
+  -v /c/Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> ^
+  -i /src/input.ditamap ^
+  -o /src/out ^
   -f html5 -v</codeblock>
           </div>
         </stepxmp>

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -41,25 +41,25 @@
           <li>To retrieve docker images from the GitHub Package Registry, you will also need a GitHub account.</li>
         </ul></p>
     </prereq>
-    <steps>
+    <steps outputclass="multi-platform">
       <step>
         <cmd>Install Docker for your operating system.</cmd>
         <choices>
-          <choice>
+          <choice platform="windows">
             <xref href="https://docs.docker.com/docker-for-windows/install/" scope="external" format="html">Install
               Docker Desktop on Windows</xref>
           </choice>
-          <choice>
+          <choice platform="mac">
             <xref href="https://docs.docker.com/docker-for-mac/install" scope="external" format="html">Install Docker
               Desktop on Mac</xref>
           </choice>
-          <choice>On macOS, you can also install Docker Desktop via
+          <choice platform="mac">On macOS, you can also install Docker Desktop via
             <xref keyref="homebrew"/>:
             <codeblock>$ <cmdname>brew</cmdname> cask install docker
 <systemoutput>Downloading…</systemoutput></codeblock>
           </choice>
-          <choice>On Linux, install Docker Community Edition (CE) via your operating system’s package manager, for
-            example: <codeblock>$ <cmdname>sudo</cmdname> apt-get install docker-ce</codeblock></choice>
+          <choice platform="linux">On Linux, install Docker Community Edition (CE) via your operating system’s package manager, for
+            example: <codeblock outputclass="language-bash">$ <cmdname>sudo</cmdname> apt-get install docker-ce</codeblock></choice>
         </choices>
       </step>
       <step>
@@ -78,7 +78,7 @@
             <cmd>On the command line, run the <cmdname>docker</cmdname> command to log in with your GitHub
               credentials.</cmd>
             <stepxmp>
-              <codeblock><cmdname>docker</cmdname> login docker.pkg.github.com -u <varname>USERNAME</varname> -p <varname>PASSWORD/TOKEN</varname></codeblock>
+              <codeblock outputclass="language-bash"><cmdname>docker</cmdname> login docker.pkg.github.com -u <varname>USERNAME</varname> -p <varname>PASSWORD/TOKEN</varname></codeblock>
             </stepxmp>
             <info>For more information, see
               <xref
@@ -91,7 +91,7 @@
         <cmd>To build output, map a host directory to a container volume and specify options for the
             <cmdname>dita</cmdname> command.</cmd>
         <stepxmp>
-          <codeblock>$ <cmdname>docker</cmdname> run -it \
+          <codeblock outputclass="language-bash">$ <cmdname>docker</cmdname> run -it \
   -v /Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \
   -i /src/input.ditamap \
   -o /src/out \
@@ -107,13 +107,15 @@
               <li><option>-v</option> displays build progress messages with verbose logging</li>
             </ul>
           </p>
-          <p>On Windows, if your <filepath>Users</filepath> directory is on the <filepath>C:\</filepath> drive, use
+          <div>
+          <p platform="windows">On Windows, if your <filepath>Users</filepath> directory is on the <filepath>C:\</filepath> drive, use
               <filepath>/c/Users/…</filepath> to map the host directory:</p>
-          <codeblock>C:\Users\username> <cmdname>docker</cmdname> run -it \
+            <codeblock outputclass="language-batch">C:\Users\username> <cmdname>docker</cmdname> run -it \
   -v /c/Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \
   -i /src/input.ditamap \
   -o /src/out \
   -f html5 -v</codeblock>
+          </div>
         </stepxmp>
         <info>
           <note>The DITA-OT container image uses the <codeph>ENTRYPOINT</codeph> instruction to run the

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -55,7 +55,7 @@
           </choice>
           <choice platform="mac">On macOS, you can also install Docker Desktop via
             <xref keyref="homebrew"/>:
-            <codeblock>$ <cmdname>brew</cmdname> cask install docker
+            <codeblock outputclass="language-bash">$ <cmdname>brew</cmdname> cask install docker
 <systemoutput>Downloading…</systemoutput></codeblock>
           </choice>
           <choice platform="linux">On Linux, install Docker Community Edition (CE) via your operating system’s package manager, for
@@ -107,8 +107,8 @@
               <li><option>-v</option> displays build progress messages with verbose logging</li>
             </ul>
           </p>
-          <div>
-          <p platform="windows">On Windows, if your <filepath>Users</filepath> directory is on the <filepath>C:\</filepath> drive, use
+          <div platform="windows">
+            <p>On Windows, if your <filepath>Users</filepath> directory is on the <filepath>C:\</filepath> drive, use
               <filepath>/c/Users/…</filepath> to map the host directory:</p>
             <codeblock outputclass="language-batch">C:\Users\username> <cmdname>docker</cmdname> run -it \
   -v /c/Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \

--- a/topics/using-project-files.dita
+++ b/topics/using-project-files.dita
@@ -103,7 +103,7 @@
       <step>
         <cmd>Pass your project file to the <cmdname>dita</cmdname> command to build output.</cmd>
         <stepxmp>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname></codeblock>
         </stepxmp>
       </step>
       <step importance="optional">
@@ -112,14 +112,14 @@
         <stepxmp>
           <p>For example, to build output once with <xmlelement>draft</xmlelement> and
               <xmlelement>required-cleanup</xmlelement> content:</p>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname> <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname> <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
         </stepxmp>
       </step>
       <step importance="optional">
         <cmd>If your project contains multiple deliverables, you can pass the <parmname>--deliverable</parmname> option
           to generate output for a single deliverable ID.</cmd>
         <stepxmp>
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>all.xml</varname> <parmname>--deliverable</parmname>=<option>htmlhelp</option></codeblock>
+          <codeblock outputclass="syntax-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>all.xml</varname> <parmname>--deliverable</parmname>=<option>htmlhelp</option></codeblock>
         </stepxmp>
       </step>
     </steps>

--- a/topics/using-project-files.dita
+++ b/topics/using-project-files.dita
@@ -103,7 +103,7 @@
       <step>
         <cmd>Pass your project file to the <cmdname>dita</cmdname> command to build output.</cmd>
         <stepxmp>
-          <codeblock><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname></codeblock>
         </stepxmp>
       </step>
       <step importance="optional">
@@ -112,14 +112,14 @@
         <stepxmp>
           <p>For example, to build output once with <xmlelement>draft</xmlelement> and
               <xmlelement>required-cleanup</xmlelement> content:</p>
-          <codeblock><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname> <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>pdf.xml</varname> <parmname>--args.draft</parmname>=<option>yes</option></codeblock>
         </stepxmp>
       </step>
       <step importance="optional">
         <cmd>If your project contains multiple deliverables, you can pass the <parmname>--deliverable</parmname> option
           to generate output for a single deliverable ID.</cmd>
         <stepxmp>
-          <codeblock><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>all.xml</varname> <parmname>--deliverable</parmname>=<option>htmlhelp</option></codeblock>
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--project</parmname>=<varname>all.xml</varname> <parmname>--deliverable</parmname>=<option>htmlhelp</option></codeblock>
         </stepxmp>
       </step>
     </steps>


### PR DESCRIPTION
Add platform profiling controls, triggered by `multi-platform` class. This PR adopts changes from dita-ot/website#408.

Example output:

-   https://preview-pr-300--dita-ot.netlify.app/dev/topics/build-using-dita-command.html
-   https://preview-pr-300--dita-ot.netlify.app/dev/topics/determining-version-of-ditaot.html
-   https://preview-pr-300--dita-ot.netlify.app/dev/topics/using-docker-images.html