### PR TITLE
Add configuration.properties to Installing plug-ins 

### DIFF
--- a/resources/conref-task.dita
+++ b/resources/conref-task.dita
@@ -46,8 +46,10 @@
               </li>
               <li><ph id="plugin-integrate-all">If no <varname>ID</varname>, <varname>URL</varname>, or
                     <varname>file</varname> argument is provided, the installation process reloads the current set of
-                  plug-ins from the <filepath>plugins</filepath> directory. This approach can be used to add or remove
-                  multiple plug-ins at once, or any individual plug-ins you have already copied to (or removed from) the
+                  plug-ins from the <filepath>plugins</filepath> directory or that are defined in
+                    <filepath>configuration.properties</filepath> using the <parmname>pluginsdir</parmname> property in the
+                    <filepath>config</filepath> directory. This approach can be used to add or remove multiple plug-ins
+                  at once, or any individual plug-ins you have already copied to (or removed from) the
                     <filepath>plugins</filepath> directory. Any plug-ins added or removed in the process will be listed
                   by their plug-in ID.</ph></li>
               <li><note id="plugin-remove-subdir" type="attention">The <cmdname>uninstall</cmdname> subcommand also

--- a/topics/using-plugins.ditamap
+++ b/topics/using-plugins.ditamap
@@ -18,6 +18,7 @@
       </relcell>
       <relcell>
         <topicref keyref="plugins-registry"/>
+        <topicref keyref="configuration-properties-file"/>
       </relcell>
     </relrow>
   </reltable>


### PR DESCRIPTION
## Description
The "Installing plug-ins" topic did not have any information about or links to being able to use the `configuration.properties` file to install plug-ins. This pull-request adds that information and a reltable link between the installing-plugins and configuration.properties topics.

## How Has This Been Tested?
I have built the website locally using the develop branch of DITA-OT to review the website output.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.

---

Signed-off-by: Lief Erickson <lief.erickson@gmail.com>
