### PR TITLE
Align command-line examples with `dita` in $PATH

### DIFF
--- a/resources/conref-task.dita
+++ b/resources/conref-task.dita
@@ -20,7 +20,7 @@
         <dlentry>
           <dt>Standard Path / Directory Names</dt>
           <dd><filepath id="ot-dir"><varname>dita-ot-dir</varname></filepath></dd>
-          <dd><filepath id="dita-cmd"><varname>dita-ot-dir</varname>/bin/<cmdname>dita</cmdname></filepath></dd>
+          <dd><filepath id="dita-cmd"><cmdname>dita</cmdname></filepath></dd>
           <dd><filepath id="docsrc-dir"><varname>dita-ot-dir</varname>/docsrc</filepath></dd>
           <dd><filepath id="samples-dir"><varname>dita-ot-dir</varname>/docsrc/samples</filepath></dd>
           <dd><filepath id="samples-absolute"
@@ -76,12 +76,10 @@
         </cmd>
       </step>
       <step>
-        <cmd id="open-terminal">Open a command prompt or terminal session, and then change to the directory where DITA
-          Open Toolkit is installed.</cmd>
+        <cmd id="open-terminal">Open a command prompt or terminal session.</cmd>
         <info>
           <ul id="basic-variables">
-            <li id="novice-variables-1"><filepath conref="#ID/ot-dir"/> is the DITA-OT installation directory.</li>
-            <li id="novice-variables-2"><varname>input-file</varname> is the DITA map or DITA file that you want to
+            <li id="novice-variables"><varname>input-file</varname> is the DITA map or DITA file that you want to
               process.</li>
             <!-- ↓ excerpt-variables ↓ -->
             <li id="novice-variables-last" audience="novice">
@@ -89,7 +87,7 @@
                 <varname>format</varname> is the output format (transformation type). This argument corresponds to the
                 common parameter <parmname>transtype</parmname>. Use the same values as for the
                   <parmname>transtype</parmname> build parameter, for example <option>html5</option> or
-                  <option>pdf</option>. </p>
+                  <option>pdf</option>.</p>
             </li>
             <!-- ↑ end-excerpt ↑ -->
             <li id="expert-variables-last" audience="expert">
@@ -126,13 +124,6 @@
           <p>If processing is successful, nothing is printed in the terminal window. The built output is written to the
             specified output directory (by default, in the <filepath>out</filepath> subdirectory of the current
             directory).</p>
-          <note id="dita-in-path" type="tip">Add the absolute path for <filepath conref="#ID/ot-dir"
-              /><filepath>/bin</filepath> to the
-            <xref keyref="PATH"/> to run the <cmdname>dita</cmdname> command from any location on the file system
-            without typing the path.
-            <indexterm><cmdname>dita</cmdname> command
-              <indexterm>PATH environment variable</indexterm></indexterm>
-          </note>
         </stepresult>
       </step>
       <step>

--- a/topics/determining-version-of-ditaot.dita
+++ b/topics/determining-version-of-ditaot.dita
@@ -31,25 +31,9 @@
       </step>
       <step>
         <cmd>Issue the following command:</cmd>
-        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
-          <chrow platform="linux mac">
-            <choption>Linux or macOS&#xA0;</choption>
-            <chdesc>
-              <cmdname>bin/dita</cmdname>
-              <parmname>--version</parmname>
-            </chdesc>
-          </chrow>
-          <chrow platform="windows">
-            <choption>Windows</choption>
-            <chdesc>
-              <cmdname>bin\dita</cmdname>
-              <parmname>--version</parmname>
-            </chdesc>
-          </chrow>
-        </choicetable>
-        <info>
-          <note conkeyref="conref-task/dita-in-path"/>
-        </info>
+        <stepxmp>
+          <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--version</parmname></codeblock>
+        </stepxmp>
       </step>
     </steps>
     <result>

--- a/topics/dita-command-help.dita
+++ b/topics/dita-command-help.dita
@@ -32,25 +32,9 @@
       </step>
       <step>
         <cmd>Issue the following command:</cmd>
-        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
-          <chrow platform="linux mac">
-            <choption>Linux or macOS&#xA0;</choption>
-            <chdesc>
-              <cmdname>bin/dita</cmdname>
-              <parmname>--help</parmname>
-            </chdesc>
-          </chrow>
-          <chrow platform="windows">
-            <choption>Windows</choption>
-            <chdesc>
-              <cmdname>bin\dita</cmdname>
-              <parmname>--help</parmname>
-            </chdesc>
-          </chrow>
-        </choicetable>
-        <info>
-          <note conkeyref="conref-task/dita-in-path"/>
-        </info>
+        <stepxmp>
+          <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--help</parmname></codeblock>
+        </stepxmp>
       </step>
       <step importance="optional">
         <cmd>For details on the arguments and options available for each subcommand, pass the

--- a/topics/dita2dita.dita
+++ b/topics/dita2dita.dita
@@ -56,10 +56,11 @@
     <section id="generating-normalized-dita-output">
       <title>Generating normalized DITA output</title>
       <p>Run the <cmdname>dita</cmdname> command and set the value of the output <parmname>--format</parmname> option to
-          <option>dita</option>:</p><codeblock xml:space="preserve"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>dita</option></codeblock>
+          <option>dita</option>:</p>
+      <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>dita</option></codeblock>
       <p>where:</p>
       <ul>
-        <li conkeyref="conref-task/novice-variables-1" conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+        <li conkeyref="conref-task/novice-variables"/>
       </ul>
     </section>
   </body>

--- a/topics/dita2eclipsehelp.dita
+++ b/topics/dita2eclipsehelp.dita
@@ -58,8 +58,7 @@
     <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>eclipsehelp</option></codeblock>
     <p>where:</p>
     <ul>
-      <li conkeyref="conref-task/novice-variables-1"
-        conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+      <li conkeyref="conref-task/novice-variables"/>
     </ul>
   </conbody>
 </concept>

--- a/topics/dita2html5.dita
+++ b/topics/dita2html5.dita
@@ -41,8 +41,7 @@
     <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>html5</option></codeblock>
     <p>where:</p>
     <ul>
-      <li conkeyref="conref-task/novice-variables-1"
-        conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+      <li conkeyref="conref-task/novice-variables"/>
     </ul>
   </conbody>
 </concept>

--- a/topics/dita2htmlhelp.dita
+++ b/topics/dita2htmlhelp.dita
@@ -65,8 +65,7 @@
     <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>htmlhelp</option></codeblock>
     <p>where:</p>
     <ul>
-      <li conkeyref="conref-task/novice-variables-1"
-        conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+      <li conkeyref="conref-task/novice-variables"/>
     </ul>
   </conbody>
 </concept>

--- a/topics/dita2markdown.dita
+++ b/topics/dita2markdown.dita
@@ -47,8 +47,7 @@
       <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>markdown</option></codeblock>
       <p>where:</p>
       <ul>
-        <li conkeyref="conref-task/novice-variables-1"
-          conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+        <li conkeyref="conref-task/novice-variables"/>
       </ul></section>
   </body>
 </topic>

--- a/topics/dita2pdf.dita
+++ b/topics/dita2pdf.dita
@@ -29,8 +29,7 @@
     <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>pdf</option></codeblock>
     <p>where:</p>
     <ul>
-      <li conkeyref="conref-task/novice-variables-1"
-        conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+      <li conkeyref="conref-task/novice-variables"/>
     </ul>
   </conbody>
 </concept>

--- a/topics/dita2xhtml.dita
+++ b/topics/dita2xhtml.dita
@@ -37,8 +37,7 @@
     <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<option>xhtml</option></codeblock>
     <p>where:</p>
     <ul>
-      <li conkeyref="conref-task/novice-variables-1"
-        conrefend="../resources/conref-task.dita#ID/novice-variables-2"/>
+      <li conkeyref="conref-task/novice-variables"/>
     </ul>
   </conbody>
 </concept>

--- a/topics/installing-client.dita
+++ b/topics/installing-client.dita
@@ -47,14 +47,16 @@
       <step>
         <cmd>Extract the contents of the package to the directory where you want to install DITA-OT.</cmd>
       </step>
-      <step importance="optional">
-        <cmd>Add the absolute path for the <filepath>bin</filepath> directory to the
+      <step>
+        <cmd>Add the absolute path for the <filepath>bin</filepath> folder of the DITA-OT installation directory to the
           <xref keyref="PATH"/>.</cmd>
         <stepresult>
-          <p>This defines the necessary environment variable to run the <cmdname>dita</cmdname> command from the command
-            line.</p>
-          <note type="tip">This step is recommended, as it allows the <cmdname>dita</cmdname> command to be run from any
-            location on the file system and makes it easier to transform DITA content from any folder.</note>
+          <note id="dita-in-path" type="tip">This defines the necessary environment variable that allows the
+              <cmdname>dita</cmdname> command to be run from any location on the file system without typing the path to
+            the command.
+            <indexterm><cmdname>dita</cmdname> command
+              <indexterm>PATH environment variable</indexterm></indexterm>
+          </note>
         </stepresult>
       </step>
     </steps>

--- a/topics/migrating-ant-to-dita.dita
+++ b/topics/migrating-ant-to-dita.dita
@@ -31,7 +31,10 @@
       <p>Building output with the <cmdname>dita</cmdname> command is often easier than using Ant. In particular, you can
         use <filepath>.properties</filepath> files to specify sets of DITA-OT parameters for each build.</p>
       <p>You can include the <cmdname>dita</cmdname> command in shell scripts to perform multiple builds.</p>
-      <note conkeyref="conref-task/dita-in-path"/>
+      <note type="tip">Add the absolute path for the <filepath>bin</filepath> folder of the DITA-OT installation
+        directory to the
+        <xref keyref="PATH"/> to run the <cmdname>dita</cmdname> command from any location on the file system without
+        typing the path.</note>
     </context>
     <steps>
       <step>

--- a/topics/using-dita-command.dita
+++ b/topics/using-dita-command.dita
@@ -24,25 +24,28 @@
     <context audience="novice">The DITA-OT client is a command-line tool with no graphical user interface. To verify
       that your installation works correctly, you can build output using the sample files included in the distribution
       package.</context>
-    <steps outputclass="multi-platform">
+    <steps>
       <step audience="novice">
         <cmd>Open a terminal window by typing the following in the search bar:</cmd>
-        <info>
-          <ul>
-            <li platform="linux mac">On Linux and macOS, type <userinput>Terminal</userinput>.</li>
-            <li platform="windows">On Windows, type <userinput>Command Prompt</userinput>.</li>
-          </ul>
-        </info>
+        <choicetable frame="topbot" relcolwidth="1* 3*" outputclass="multi-platform">
+          <chrow platform="linux mac">
+            <choption>Linux or macOS&#xA0;</choption>
+            <chdesc>Type <userinput>Terminal</userinput>.</chdesc>
+          </chrow>
+          <chrow platform="windows">
+            <choption>Windows</choption>
+            <chdesc>Type <userinput>Command Prompt</userinput>.</chdesc>
+          </chrow>
+        </choicetable>
       </step>
       <step>
         <cmd>At the command-line prompt, enter the following command:</cmd>
         <info><codeblock outputclass="syntax-bash"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<varname>input-file</varname> <parmname>--format</parmname>=<varname>format</varname> <ph audience="expert">[<varname>options</varname>]</ph></codeblock>
           <p>where:</p>
           <ul>
-            <li conkeyref="conref-task/novice-variables-1"
+            <li conkeyref="conref-task/novice-variables"
               conrefend="../resources/conref-task.dita#ID/novice-variables-last" audience="novice"/>
-            <li conkeyref="conref-task/novice-variables-1"
-              conrefend="../resources/conref-task.dita#ID/novice-variables-2" audience="expert"/>
+            <li conkeyref="conref-task/novice-variables" audience="expert"/>
             <li conkeyref="conref-task/expert-variables-last" audience="expert"/>
             <li conkeyref="conref-task/options" audience="expert"/>
           </ul></info>
@@ -50,9 +53,9 @@
       </step>
     </steps>
     <example audience="novice">
-      <p>Run from <filepath conkeyref="conref-task/samples-dir"/>, the following command generates
-        HTML5 output for the <filepath>sequence.ditamap</filepath> file:</p>
-      <codeblock outputclass="syntax-bash multi-platform"><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
+      <p>Run from <filepath conkeyref="conref-task/samples-dir"/>, the following command generates HTML5 output for the
+          <filepath>sequence.ditamap</filepath> file:</p>
+      <codeblock><filepath conkeyref="conref-task/dita-cmd"/> <parmname>--input</parmname>=<filepath>sequence.ditamap</filepath> <parmname>--format</parmname>=<option>html5</option></codeblock>
       <indexterm>DITA maps
         <indexterm><cmdname>dita</cmdname> command example</indexterm></indexterm>
     </example>


### PR DESCRIPTION
The command-line samples we provide to illustrate how to do various things with the `dita` command currently use a variety of paths to refer to the `dita` command depending on the assumed current directory.

- `dita-ot-dir/bin/dita …`
- `bin/dita …`
- `dita …`

These changes adjust the installation instructions to explicitly include the addition of the DITA-OT `bin` directory to $PATH, which allows us to simplify the sample commands to all begin with `dita …`.
