### PR TITLE
Add links to previous release notes

### DIFF
--- a/resources/common-toc.ditamap
+++ b/resources/common-toc.ditamap
@@ -6,7 +6,9 @@
   <title>DITA Open Toolkit <keyword keyref="release"/></title>
 
   <topicref keyref="landing-page"/>
-  <topicref keyref="release-notes"/>
+  <topicref keyref="release-notes">
+    <topicref keyref="release-history"/>
+  </topicref>
   <topicref keyref="installing-client">
     <mapref href="../topics/installing.ditamap"/>
   </topicref>

--- a/resources/reltable.ditamap
+++ b/resources/reltable.ditamap
@@ -351,4 +351,38 @@
       </relcell>
     </relrow>
   </reltable>
+  <reltable>
+    <title>Release history</title>
+    <relheader>
+      <relcolspec linking="sourceonly"/>
+      <relcolspec linking="targetonly"/>
+    </relheader>
+    <relrow>
+      <relcell>
+        <topicref keyref="release-history"/>
+      </relcell>
+      <relcell>
+        <topicref keyref="migration"/>
+        <topicref keyref="3.5-release-notes"/>
+        <topicref keyref="3.4-release-notes"/>
+        <topicref keyref="3.3-release-notes"/>
+        <topicref keyref="3.2-release-notes"/>
+        <topicref keyref="3.1-release-notes"/>
+        <topicref keyref="3.0-release-notes"/>
+        <topicref keyref="2.5-release-notes"/>
+        <topicref keyref="2.4-release-notes"/>
+        <topicref keyref="2.3-release-notes"/>
+        <topicref keyref="2.2-release-notes"/>
+        <topicref keyref="2.1-release-notes"/>
+        <topicref keyref="2.0-release-notes"/>
+        <topicref format="html" href="http://dita-archive.xml.org/wiki/the-dita-open-toolkit" scope="external">
+          <topicmeta>
+            <linktext>DITA-OT 1.8 - 1.0 Release Notes</linktext>
+            <shortdesc>The DITA-OT project archive at dita-archive.xml.org provides news about earlier toolkit releases, and
+              release notes for legacy versions.</shortdesc>
+          </topicmeta>
+        </topicref>
+      </relcell>
+    </relrow>
+  </reltable>
 </map>

--- a/resources/reusable-components.dita
+++ b/resources/reusable-components.dita
@@ -165,15 +165,15 @@
         </dlentry>
       </dl>
     </section>
-    
+
     <section id="dita-ot-migration-tip">
       <title>Recommendations for upgrading DITA-OT customizations</title>
-      <p id="migration-recommendation">When migrating customizations, identify the version of the toolkit you're currently using (base version) and
-        the version of the toolkit you want to migrate to (target version). Then, review all of the migration changes
-        described in <i>all</i> of the versions from the base through the target. For instance, if you're currently on
-        2.2 and want to move to 3.3, you should review all of the changes in 2.3 through 3.3. You may want to start at
-        the oldest version and read forward so you can chronologically follow the changes, since it is possible that
-        files or topics have had multiple changes. </p>
+      <p id="migration-recommendation">When migrating customizations, identify the version of the toolkit you're
+        currently using (base version) and the version of the toolkit you want to migrate to (target version). Then,
+        review all of the migration changes described in <i>all</i> of the versions from the base through the target.
+        For instance, if you're currently on 2.2 and want to move to 3.3, you should review all of the changes in 2.3
+        through 3.3. You may want to start at the oldest version and read forward so you can chronologically follow the
+        changes, since it is possible that files or topics have had multiple changes. </p>
     </section>
   </conbody>
 </concept>

--- a/resources/reusable-components.dita
+++ b/resources/reusable-components.dita
@@ -165,5 +165,15 @@
         </dlentry>
       </dl>
     </section>
+    
+    <section id="dita-ot-migration-tip">
+      <title>Recommendations for upgrading DITA-OT customizations</title>
+      <p id="migration-recommendation">When migrating customizations, identify the version of the toolkit you're currently using (base version) and
+        the version of the toolkit you want to migrate to (target version). Then, review all of the migration changes
+        described in <i>all</i> of the versions from the base through the target. For instance, if you're currently on
+        2.2 and want to move to 3.3, you should review all of the changes in 2.3 through 3.3. You may want to start at
+        the oldest version and read forward so you can chronologically follow the changes, since it is possible that
+        files or topics have had multiple changes. </p>
+    </section>
   </conbody>
 </concept>

--- a/resources/source-files.ditamap
+++ b/resources/source-files.ditamap
@@ -179,6 +179,7 @@
   <keydef keys="reducing-processing-time" href="../topics/reducing-processing-time.dita"/>
   <keydef keys="reference" href="../reference/index.dita"/>
   <keydef keys="referencing-other-plugins" href="../topics/referencing-other-plugins.dita"/>
+  <keydef keys="release-history" href="../topics/release-history.dita"/>
   <keydef keys="release-notes" href="../release-notes/index.dita"/>
   <keydef keys="reusable-components" href="../resources/reusable-components.dita"/>
   <keydef keys="third-party-software" href="../reference/third-party-software.dita"/>

--- a/topics/migration.dita
+++ b/topics/migration.dita
@@ -26,12 +26,7 @@
     <section>
       <p>In some cases, you may be able to remove old code that is no longer needed. In other cases, you may need to
         refactor your code to point to the modified extension points, templates or modes in recent toolkit versions.</p>
-      <p>When migrating customizations, identify the version of the toolkit you're currently using (base version) and
-        the version of the toolkit you want to migrate to (target version). Then, review all of the migration changes
-        described in <i>all</i> of the versions from the base through the target. For instance, if you're currently on
-        2.2 and want to move to 3.3, you should review all of the changes in 2.3 through 3.3. You may want to start at
-        the oldest version and read forward so you can chronologically follow the changes, since it is possible that
-        files or topics have had multiple changes. </p>
+      <p conkeyref="reusable-components/migration-recommendation"/>
       <note>
         <p conkeyref="conref-task/semver-info" conrefend="semver-plugins"/></note>
     </section>

--- a/topics/release-history.dita
+++ b/topics/release-history.dita
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!--  This file is part of the DITA Open Toolkit project. See the accompanying LICENSE file for applicable license.  -->
+
 <topic id="dita_ot_release_history">
-    <title>DITA-OT release history</title>
-    <shortdesc>If you need details about any DITA-OT version, you can find the information on these pages.</shortdesc>
-    <body>
-        <p conkeyref="reusable-components/migration-recommendation"/>
-    </body>
+  <title>DITA-OT release history</title>
+  <shortdesc>If you need details about any DITA-OT version, you can find the information on these pages.</shortdesc>
+  <body>
+    <p conkeyref="reusable-components/migration-recommendation"/>
+  </body>
 </topic>

--- a/topics/release-history.dita
+++ b/topics/release-history.dita
@@ -4,6 +4,9 @@
 
 <topic id="dita_ot_release_history">
   <title>DITA-OT release history</title>
+  <titlealts>
+    <navtitle>Release history</navtitle>
+  </titlealts>
   <shortdesc>If you need details about any DITA-OT version, you can find the information on these pages.</shortdesc>
   <body>
     <p conkeyref="reusable-components/migration-recommendation"/>

--- a/topics/release-history.dita
+++ b/topics/release-history.dita
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="dita_ot_release_history">
+    <title>DITA-OT release history</title>
+    <shortdesc>If you need details about any DITA-OT version, you can find the information on these pages.</shortdesc>
+    <body>
+        <p conkeyref="reusable-components/migration-recommendation"/>
+    </body>
+</topic>


### PR DESCRIPTION
## Description
Add a topic that includes links to the web pages for the release notes of previous releases. 

## Motivation and Context
When upgrading the recommendation is to read _all_ of the release notes from the base version you're coming from to the target version you're going to, but we don't provide easy access to that history. Some of that information is buried in the migration topic deep in the docs. This page makes that finding those pages easier since people upgrading are likely to be reading the release notes.

## How Has This Been Tested?
Built the "site" target locally. Local HTML and PDF were not specifically tested. 

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>