### PR TITLE
Style HTML output based on Almond.CSS

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,4 +24,5 @@ publishing.ditamap
 release-notes/changes.ditamap
 release-notes/history.dita
 release-notes/rel*.dita
+resources/dita-ot-doc.css
 samples/plugins/

--- a/resources/dita-ot-doc.css
+++ b/resources/dita-ot-doc.css
@@ -1,10 +1,16 @@
 /* DITA Open Toolkit documentation style */
 
-/* ---------------------------------------------------------------------------------------------- */
+/* Based on almond.css by Alvaro Montoro */
 
-/* Imported from: 'https://github.com/alvaromontoro/almond.css/blob/bcbb95b/dist/almond.lite.css' */
+/*
+  Copyright (c) 2019 - Alvaro Montoro (alvaromontoro@gmail.com)
 
-/* ↓ add almond.lite.css ↓ */
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 /************************************************************/
 /*                        Almond.CSS                        */

--- a/resources/dita-ot-doc.css
+++ b/resources/dita-ot-doc.css
@@ -204,6 +204,13 @@ select {
   select:disabled {
     background: var(--secondary-lighter);
     color: var(--secondary-light); }
+  input:not([type="file"])::-webkit-calendar-picker-indicator,
+  optgroup::-webkit-calendar-picker-indicator,
+  option::-webkit-calendar-picker-indicator,
+  textarea::-webkit-calendar-picker-indicator,
+  select::-webkit-calendar-picker-indicator {
+    display: none;
+    background: none; }
 
 input:not([type="file"]):not([type="image"]):not(:invalid):not(:disabled):not([disabled]):not([readonly]):hover,
 textarea:not(:invalid):not(:disabled):not([disabled]):not([readonly]):hover,
@@ -312,7 +319,8 @@ input[type="checkbox"] {
   border-radius: 50%;
   border: 1px solid var(--secondary-light);
   box-shadow: inset 0 0 0 0.185rem var(--secondary-bg);
-  background: var(--secondary-bg); }
+  background: var(--secondary-bg);
+  vertical-align: text-top; }
   input[type="radio"][type="checkbox"],
   input[type="checkbox"][type="checkbox"] {
     border-radius: var(--border-radius); }
@@ -324,13 +332,25 @@ input[type="checkbox"] {
     box-shadow: inset 0 0 0 0.185rem var(--secondary-lighter);
     background: var(--secondary-lighter); }
 
+select:not([multiple]) {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M0,10 20,30 40,10' fill='none' stroke='%23999' stroke-width='2'/></svg>");
+  background-size: 1em 1em;
+  background-repeat: no-repeat;
+  background-position: right 0.5em center;
+  padding-right: 2em; }
+  select:not([multiple]):hover, select:not([multiple]):active {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M0,10 20,30 40,10' fill='none' stroke='%23222' stroke-width='2'/></svg>"); }
+
 select[multiple] {
   min-height: 10rem;
   padding: 0; }
   select[multiple] option:checked {
     background: var(--secondary-light) linear-gradient(0deg, var(--secondary-light) 0%, var(--secondary-light) 100%); }
   select[multiple]:focus option:checked {
-    background: var(--primary) linear-gradient(0deg, var(--primary) 0%, var(--primary) 100%); }
+    background: var(--primary) linear-gradient(0deg, var(--primary) 0%, var(--primary) 100%);
+    color: var(--primary-bg); }
 
 optgroup {
   border: 0;
@@ -424,6 +444,9 @@ code {
 /*font-weight: var(--font-weight-bold);*/
 /*padding: 0 0.25rem;*/ }
 
+del {
+  text-decoration: line-through var(--primary); }
+
 details {
   border: 1px solid var(--secondary-light);
   border-radius: var(--border-radius);
@@ -505,6 +528,9 @@ hr {
 img {
   border: 0;
   max-width: 100%; }
+
+ins {
+  text-decoration: underline var(--primary); }
 
 kbd {
   background-color: var(--secondary-lighter);

--- a/resources/dita-ot-doc.css
+++ b/resources/dita-ot-doc.css
@@ -1,42 +1,685 @@
 /* DITA Open Toolkit documentation style */
 
+/* ---------------------------------------------------------------------------------------------- */
+
+/* Imported from: 'https://github.com/alvaromontoro/almond.css/blob/bcbb95b/dist/almond.lite.css' */
+
+/* ↓ add almond.lite.css ↓ */
+
+/************************************************************/
+/*                        Almond.CSS                        */
+/************************************************************/
+/** Author:  Alvaro Montoro                                **/
+/** Project: https://github.com/alvaromontoro/almond.css   **/
+/************************************************************/
+:root {
+  /* Colors */
+  --primaryH: 210;
+  --primaryS: 50%;
+  --primaryL: 40%;
+  --primary-bg: #fff;
+  --secondaryH: 0;
+  --secondaryS: 0%;
+  --secondaryL: 13%;
+  --secondary-bg: #fff;
+  /* Font */
+  --font-family: Helvetica, Arial, sans-serif;
+  --font-size-root: 16px;
+  --font-weight-bolder: 700;
+  --font-weight-bold: 400;
+  --font-weight-normal: 200;
+  --font-weight-thin: 100;
+  --line-height: 1.75rem;
+  --heading-margin: 1.5rem 0 1rem;
+  /* Inputs */
+  --border-radius: 2px;
+  /* Status */
+  --error: #d00;
+  --warning: #ec0;
+  --info: #369;
+  --correct: #080; }
+
+:root {
+  /* Calculated colors */
+  --primary: hsl(var(--primaryH), var(--primaryS), var(--primaryL));
+  --primary-bright: hsl(var(--primaryH), calc(var(--primaryS) * 1.25), 90%);
+  --primary-transparent: hsla(var(--primaryH), var(--primaryS), var(--primaryL), 0.05);
+  --primary-dark: hsl(var(--primaryH), var(--primaryS), calc(var(--primaryL) * 0.5));
+  --primary-darker: hsl(var(--primaryH), var(--primaryS), calc(var(--primaryL) * 0.2));
+  --primary-light: hsl(var(--primaryH), var(--primaryS), 75%);
+  --primary-lighter: hsl(var(--primaryH), var(--primaryS), 96%);
+  --secondary: hsl(var(--secondaryH), var(--secondaryS), var(--secondaryL));
+  --secondary-transparent: hsl(var(--secondaryH), var(--secondaryS), var(--secondaryL), 0.05);
+  --secondary-dark: hsl(var(--secondaryH), var(--secondaryS), calc(var(--secondaryL) * 0.5));
+  --secondary-darker: hsl(var(--secondaryH), var(--secondaryS), calc(var(--secondaryL) * 0.2));
+  --secondary-light: hsl(var(--secondaryH), var(--secondaryS), 75%);
+  --secondary-lighter: hsl(var(--secondaryH), var(--secondaryS), 96%); }
+
+html {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: var(--secondary-bg);
+  color: var(--secondary);
+  font-family: var(--font-family);
+  font-size: var(--font-size-root);
+  font-weight: var(--font-weight-normal);
+  margin: 0;
+  padding: 0; }
+
+body {
+  font-size: 1rem;
+  margin: auto auto;
+  padding: 1rem; }
+
+@media all and (min-width: 1024px) {
+  body {
+    max-width: 920px; } }
+
+@media all and (min-width: 1200px) {
+body {
+    max-width: 1080px; } }
+
+:focus {
+  outline: 1px dashed var(--primary);
+  outline-offset: 2px; }
+
+[hidden],
+template {
+  display: none; }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--brand-primary);
+/*font-weight: var(--font-weight-normal);*/
+  margin: var(--heading-margin); }
+
+h1 {
+  font-size: 2.5rem; }
+
+h2 {
+  font-size: 2rem; }
+
+h3 {
+  font-size: 1.66rem; }
+
+h4 {
+  font-size: 1.45rem; }
+
+h5 {
+  font-size: 1.25rem;
+  font-weight: var(--font-weight-bolder); }
+
+h6 {
+  font-size: 1.125rem;
+  font-weight: var(--font-weight-bolder); }
+
+ul,
+ol {
+  margin: 0.5rem 0;
+  padding-left: 1.2rem; }
+  ul ul,
+  ul ol,
+  ol ul,
+  ol ol {
+    margin: 0; }
+
+li {
+  font-size: 1rem;
+  line-height: var(--line-height);
+  margin: 0.5rem 0;
+  max-width: 80ch;
+  max-width: calc(80ch - 3rem); }
+
+table {
+  background-color: var(--secondary-bg);
+  border: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%; }
+
+thead {
+  background-color: var(--secondary-lighter);
+/*box-shadow: inset 0 -2px var(--secondary);*/ }
+
+tfoot {
+  box-shadow: inset 0 2px var(--secondary); }
+/*
+tbody tr:nth-child(even) {
+  background-color: var(--secondary-lighter); }
+*/
+tbody tr:hover {
+  background-color: var(--primary-lighter); }
+
+td,
+th {
+  padding: 0.5rem;
+  vertical-align: top; }
+
+th {
+  font-weight: var(--font-weight-bold); }
+
+input:not([type="file"]),
+optgroup,
+option,
+textarea,
+select {
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  color: inherit;
+  font: inherit;
+  font-size: 1rem;
+  height: 2.5rem;
+  line-height: normal;
+  margin: 0;
+  padding: 0 0.5rem;
+  max-width: 100%;
+  min-width: 15rem;
+  text-transform: none;
+  vertical-align: bottom; }
+  input:not([type="file"]):invalid,
+  optgroup:invalid,
+  option:invalid,
+  textarea:invalid,
+  select:invalid {
+    border-color: var(--error); }
+  input:not([type="file"]):invalid:hover,
+  optgroup:invalid:hover,
+  option:invalid:hover,
+  textarea:invalid:hover,
+  select:invalid:hover {
+    border: 1px solid #aa0000; }
+  input:not([type="file"])[disabled], input:not([type="file"]):disabled,
+  optgroup[disabled],
+  optgroup:disabled,
+  option[disabled],
+  option:disabled,
+  textarea[disabled],
+  textarea:disabled,
+  select[disabled],
+  select:disabled {
+    background: var(--secondary-lighter);
+    color: var(--secondary-light); }
+
+input:not([type="file"]):not([type="image"]):not(:invalid):not(:disabled):not([disabled]):not([readonly]):hover,
+textarea:not(:invalid):not(:disabled):not([disabled]):not([readonly]):hover,
+select:not(:invalid):not(:disabled):not([disabled]):not([readonly]):hover {
+  border: 1px solid var(--secondary); }
+
+input[type="color"] {
+  padding: 0.125rem; }
+
+input[type="range"] {
+  padding: 0; }
+
+textarea {
+  height: 5rem;
+  line-height: 1.5rem;
+  overflow: auto; }
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+  appearance: textfield; }
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none; }
+
+input[type="radio"],
+input[type="checkbox"],
+input[type="image"],
+input[type="file"] {
+  border: 0;
+  box-sizing: border-box;
+  height: auto;
+  max-width: initial;
+  min-width: auto;
+  padding: 0; }
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  appearance: button;
+  background-color: var(--primary);
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  color: var(--primary-bg);
+  cursor: pointer;
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: var(--font-weight-bold);
+  min-height: 2.5rem;
+  max-width: auto;
+  min-width: auto;
+  overflow: visible;
+  padding: 0 1rem;
+  text-transform: uppercase; }
+  button[disabled], button:disabled,
+  input[type="button"][disabled],
+  input[type="button"]:disabled,
+  input[type="reset"][disabled],
+  input[type="reset"]:disabled,
+  input[type="submit"][disabled],
+  input[type="submit"]:disabled {
+    background: var(--secondary-lighter);
+    color: var(--secondary-light); }
+  button:not(:disabled):not([disabled]):hover,
+  input[type="button"]:not(:disabled):not([disabled]):hover,
+  input[type="reset"]:not(:disabled):not([disabled]):hover,
+  input[type="submit"]:not(:disabled):not([disabled]):hover {
+    background-color: var(--primary-dark);
+    border: 1px solid transparent; }
+
+input[type="reset"] {
+  background-color: var(--primary-bg);
+  border: 1px solid var(--primary);
+  color: var(--primary); }
+  input[type="reset"]:not(:disabled):not([disabled]):hover {
+    background-color: var(--primary-lighter); }
+  input[type="reset"]:disabled, input[type="reset"][disabled] {
+    background: var(--secondary-lighter);
+    border: 1px solid transparent;
+    color: var(--secondary-light); }
+
+button[disabled],
+html input[disabled] {
+  cursor: default; }
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+input[type="radio"],
+input[type="checkbox"] {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 1px solid var(--secondary-light);
+  box-shadow: inset 0 0 0 0.185rem var(--secondary-bg);
+  background: var(--secondary-bg); }
+  input[type="radio"][type="checkbox"],
+  input[type="checkbox"][type="checkbox"] {
+    border-radius: var(--border-radius); }
+  input[type="radio"]:checked,
+  input[type="checkbox"]:checked {
+    background: var(--primary); }
+  input[type="radio"]:disabled,
+  input[type="checkbox"]:disabled {
+    box-shadow: inset 0 0 0 0.185rem var(--secondary-lighter);
+    background: var(--secondary-lighter); }
+
+select[multiple] {
+  min-height: 10rem;
+  padding: 0; }
+  select[multiple] option:checked {
+    background: var(--secondary-light) linear-gradient(0deg, var(--secondary-light) 0%, var(--secondary-light) 100%); }
+  select[multiple]:focus option:checked {
+    background: var(--primary) linear-gradient(0deg, var(--primary) 0%, var(--primary) 100%); }
+
+optgroup {
+  border: 0;
+  border-radius: 0;
+  font-weight: var(--font-weight-bolder);
+  padding: 0.5rem; }
+
+option {
+  border: 0;
+  border-radius: 0;
+  display: flex;
+  font-weight: var(--font-weight-normal);
+  align-items: center;
+  justify-content: flex-start; }
+  option:hover {
+    border: 0;
+    background: var(--primary-lighter); }
+
+a,
+a:link,
+a:visited,
+a:active,
+a:focus {
+  color: var(--link-color);
+  font-weight: var(--font-weight-normal);
+  text-decoration: none; }
+
+a:hover {
+  text-decoration: underline;
+  color: var(--link-hover-color); }
+
+abbr[title] {
+  border-bottom: 0;
+  text-decoration: underline dashed var(--primary); }
+
+address {
+  display: block;
+  font-style: normal;
+  margin: 1rem 0; }
+
+audio {
+  display: inline-block;
+  vertical-align: baseline;
+  max-width: 100%; }
+  audio:not([controls]) {
+    display: none;
+    height: 0; }
+
+b,
+strong {
+  font-weight: var(--font-weight-bold); }
+
+blockquote {
+  background-color: var(--secondary-transparent);
+  box-sizing: border-box;
+  display: block;
+  margin: 1rem 0 1rem 3rem;
+  max-width: 80ch;
+  max-width: calc(80ch - 3rem);
+  overflow: hidden;
+  padding: 1rem;
+  page-break-inside: avoid;
+  position: relative; }
+  blockquote::before {
+    content: open-quote;
+    color: hsla(var(--secondaryH), var(--secondaryS), var(--secondaryL), 0.15);
+    font-size: 5rem;
+    font-family: "Times New Roman", "Times", serif;
+    left: 0.25rem;
+    line-height: 1;
+    position: absolute;
+    top: 0;
+    z-index: -1; }
+  blockquote > :first-child {
+    margin-top: 0;
+    text-indent: 1rem; }
+  blockquote > :last-child {
+    margin-bottom: 0; }
+
+canvas {
+  display: inline-block;
+  vertical-align: baseline;
+  max-width: 100%; }
+
+code {
+/*background: var(--secondary-lighter);*/
+  color: var(--secondary);
+  display: inline-block;
+  font-family: monospace, monospace;
+  font-size: 1em;
+/*font-weight: var(--font-weight-bold);*/
+/*padding: 0 0.25rem;*/ }
+
+details {
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  display: block;
+  padding: 0 1rem; }
+  details summary {
+    margin: 0 -1rem;
+    padding: 1rem; }
+  details[open] summary {
+    border-bottom: 1px solid var(--secondary-light); }
+
+dfn {
+  font-style: italic;
+/*font-weight: var(--font-weight-bold);*/ }
+
+dl {
+  margin: 1rem 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  max-width: 80ch; }
+
+dt {
+  font-weight: var(--font-weight-bold);
+  margin-top: 1rem; }
+
+dd {
+  margin-left: 1rem;
+  font-style: normal; }
+
+fieldset {
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  margin: 1rem 0;
+  padding: 0 1rem 1rem 1rem; }
+  fieldset > :last-child {
+    margin-bottom: 0; }
+
+legend {
+  background: var(--secondary-lighter);
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  padding: 0.25rem 0.5rem; }
+/*
+figure {
+  background: var(--secondary-lighter);
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  display: block;
+  margin: 1rem 0;
+  padding: 1rem;
+  text-align: center; }
+*/
+figcaption {
+  font-size: 0.875rem;
+  font-style: italic; }
+
+hgroup {
+  border-left: 5px solid var(--primary);
+  display: block;
+  margin: var(--heading-margin);
+  padding-left: 1rem; }
+  hgroup h1,
+  hgroup h2,
+  hgroup h3,
+  hgroup h4,
+  hgroup h5,
+  hgroup h6 {
+    margin: 0; }
+/*
+hr {
+  border: 0;
+  border-top: 1px solid var(--secondary-light);
+  box-sizing: content-box;
+  height: 0;
+  margin: 2rem auto;
+  max-width: 15rem;
+  width: 50%; }
+*/
+img {
+  border: 0;
+  max-width: 100%; }
+
+kbd {
+  background-color: var(--secondary-lighter);
+  border: 1px solid var(--secondary-light);
+  border-radius: var(--border-radius);
+  color: var(--secondary);
+  font-family: monospace, monospace;
+  font-size: 0.9rem;
+  padding: 0.125rem 0.25rem; }
+
+mark {
+  background-color: var(--primary-bright);
+  border-left: 4px solid var(--primary-bright);
+  border-right: 4px solid var(--primary-bright);
+  color: var(--secondary-darker); }
+
+p {
+  font-size: 1rem;
+  line-height: var(--line-height);
+  margin: 1rem 0;
+  max-width: 80ch; }
+
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+  margin: 1rem 0;
+  max-width: 100%;
+  overflow: auto; }
+  pre > code {
+    display: block;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    padding: 0.5rem 0.75rem; }
+
+progress {
+  display: inline-block;
+  max-width: 100%;
+  min-width: 15rem;
+  vertical-align: baseline; }
+
+q {
+  font-style: italic; }
+  q::before {
+    content: open-quote;
+    font-style: normal; }
+  q::after {
+    content: close-quote;
+    font-style: normal; }
+
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+/*font-weight: var(--font-weight-bold);*/ }
+
+small {
+  font-size: 0.75em; }
+
+sub,
+sup {
+  font-size: 0.75em;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+svg:not(:root) {
+  border: 0;
+  max-width: 100%;
+  overflow: hidden; }
+/*
+var {
+  font-family: monospace, monospace;
+  font-size: 1em;
+  font-style: normal;
+  font-weight: var(--font-weight-bold); }
+*/
+video {
+  display: inline-block;
+  vertical-align: baseline;
+  max-width: 100%; }
+
+/* ↑ end almond.lite.css ↑ */
+
+/* ↓ add extension.images ↓ */
+
+a[rel~="external"],
+a[download] {
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+  background-position: 0rem 50%;
+  display: inline-block;
+  padding-left: 1.25rem; }
+
+a[download] {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M5,2 28,2 35,9 35,38 5,38Z M28,2 28,9 35,9 M20,10 20,30 M11,21 20,30 29,21' fill='none' stroke='%23999' stroke-width='2'/></svg>"); }
+
+a[rel~="external"] {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M28,4 39,4 39,15 M39,4 23,20 M28,9 7,9 7,34 35,34 35,15' fill='none' stroke='%23999' stroke-width='2'/></svg>"); }
+
+/* ↑ end extension.images ↑ */
+
+/* ---------------------------------------------------------------------------------------------- */
+
+:root {
+
+  /* DITA Open Toolkit overrides to Almond styles */
+
+  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-weight-bolder: 800;
+  --font-weight-bold: 600;
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --font-weight-light: 300;
+  --line-height: 1.5em;
+
+  /* DITA-OT color scheme */
+
+  --brand-primary: #1d365d;
+  --body-color: #212529;
+  --link-color: #3563ab;
+  --link-hover-color: var(--brand-primary);
+  --code-color: #6c757d;
+  --pre-bg: #f5f5f5;
+  --pre-border-color: #ccc;
+  --kbd-color: #555;
+  --table-borders: #dee2e6;
+  --headings-color: var(--brand-primary);
+}
+
 /****************************************
 Basic fonts and typography
 ****************************************/
 
-body {
-  background: white;
-  background: linear-gradient(to right, #eee 0%, #fff 300px);
-  color: #212529;
-  margin: 0;
-  padding: 1em;
-}
-
 /* ↓ header-coderef ↓ */
 .header {
-  font-size: 18pt;
   margin: 0;
   padding: 0 12px;
 }
 
 .header p {
-  color: #1d365d;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  line-height: 1.3;
-  margin: 0;
+  color: var(--headings-color);
+  font-size: 1.5rem;
+  margin: 0 0 16px;
 }
 
 .header hr {
   border: 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--secondary-light);
   height: 0;
 }
 /* ↑ end-header-ref ↑ */
 
-body {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 1rem;
+.shortdesc {
+  color: var(--code-color);
+  font-size: 1.25rem;
+  font-weight: var(--font-weight-light);
 }
+
+.context,
+.p {
+  font-size: 1rem;
+  line-height: var(--line-height);
+  margin: 1rem 0;
+  max-width: 80ch;
+}
+
+/****************************************
+Code typography
+****************************************/
 
 code,
 pre,
@@ -46,10 +689,15 @@ samp,
 .filepath,
 .msgnum,
 .option,
-.parmname {
-  color: #6c757d;
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 90%;
+.parmname,
+.varname {
+  color: var(--code-color);
+  font-family: var(--font-family-monospace);
+  font-size: 0.9375em;
+}
+
+.filepath .varname {
+  font-size: 0.9375rem;
 }
 
 .codeblock .cmdname,
@@ -58,8 +706,51 @@ samp,
 .codeblock .option,
 .codeblock .parmname,
 .codeblock .varname,
+pre code samp,
 pre code {
-  font-size: inherit;
+  font-size: 0.8125rem;
+}
+
+.syntaxdiagram {
+  color: var(--code-color);
+}
+
+.syntaxdiagram blockquote {
+  background-color: var(--pre-bg);
+  border-radius: 4px;
+  border: 1px solid var(--pre-border-color);
+  font-size: 0.8125rem;
+  line-height: 1.5rem;
+  margin: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.syntaxdiagram blockquote::before {
+  content: "";
+}
+
+.syntaxdiagram kbd {
+  background: none;
+  border: none;
+  color: var(--code-color);
+  padding: 0;
+}
+
+.syntaxdiagram code,
+.syntaxdiagram kbd,
+.syntaxdiagram pre,
+.syntaxdiagram samp,
+.syntaxdiagram var,
+.syntaxdiagram .cmdname,
+.syntaxdiagram .codeph,
+.syntaxdiagram .filepath,
+.syntaxdiagram .msgnum,
+.syntaxdiagram .option,
+.syntaxdiagram .parmname,
+.syntaxdiagram .varname {
+  color: var(--code-color);
+  font-family: var(--font-family-monospace);
+  font-size: 0.8125rem;
 }
 
 /****************************************
@@ -69,9 +760,6 @@ Headings
 h1,
 h2,
 h3 {
-  color: #1d365d;
-  font-size: 12pt;
-  font-weight: bold;
   margin-bottom: 0.75em;
   margin-left: 0;
   margin-right: 0;
@@ -79,24 +767,44 @@ h3 {
   padding: 0;
 }
 
+h1 .cmdname,
 h1 .filepath,
 h2 .filepath,
 h3 .filepath {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
+  font-size: 0.9em;
 }
 
 h1 .filepath {
-  color: #1d365d;
+  color: var(--brand-primary);
+}
+
+h1 .codeph,
+h2 code,
+h2 .codeph {
+  font-size: inherit;
+}
+
+.small.text-muted {
+  color: var(--code-color);
+  font-size: 0.8125em;
 }
 
 .sectiontitle {
-  color: #1d365d;
-  font-weight: bold;
+  color: var(--brand-primary);
+  font-size: 2rem;
+  font-weight: var(--font-weight-medium);
 }
 
 .topictitle1 {
-  margin-top: 1em;
+  font-size: 2.5rem;
+  font-weight: var(--font-weight-medium);
+  margin-top: 1.1rem;
+}
+
+.topictitle2 {
+  font-size: 2rem;
+  font-weight: var(--font-weight-medium);
 }
 
 /****************************************
@@ -107,64 +815,15 @@ main {
   margin-left: 300px;
 }
 
-blockquote,
-li,
-p {
-  line-height: 125%;
-  margin-bottom: 0.75em;
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0.75em;
-  padding: 0;
-}
-
-dd {
-  line-height: 125%;
-  margin-bottom: 0.75em;
-  margin-top: 0.75em;
-}
-
-dl {
-  line-height: 125%;
-  margin-bottom: 0.75em;
-  margin-left: 2em;
-  margin-right: 0;
-  margin-top: 0.75em;
-  padding: 0;
-}
-
-ol,
-ul {
-  margin-bottom: 0.75em;
-  margin-left: 2em;
-  margin-right: 0;
-  margin-top: 0.75em;
-  padding: 0;
-}
-
-pre {
-  margin: 10px 0;
-  padding: 0;
-}
-
 /****************************************
 Block elements
 ****************************************/
 
 .codeblock,
 .screen {
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
+  background-color: var(--pre-bg);
+  border: 1px solid var(--pre-border-color);
   border-radius: 4px;
-  padding: 6px;
-}
-
-/****************************************
-Figures
-****************************************/
-
-figcaption {
-  font-style: italic;
 }
 
 /****************************************
@@ -173,30 +832,18 @@ In-line elements
 
 .cmdname,
 .msgnum {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 /****************************************
 Links
 ****************************************/
 
-a:link {
-  color: #3563ab;
-  text-decoration: none;
-}
-
-a:visited {
-  color: #3563ab;
-}
-
-a:active,
-a:hover {
-  color: #1d365d;
-  text-decoration: underline;
-}
-
 .related-links {
-  color: #555;
+  color: var(--code-color);
+}
+.related-links strong a {
+  font-weight: var(--font-weight-bold);
 }
 
 .linklist {
@@ -208,14 +855,14 @@ Notes
 ****************************************/
 
 .note {
-  line-height: 125%;
-  margin-left: 2em;
-  margin-right: 0;
+  line-height: var(--line-height);
+  margin-left: 1rem;
+  margin-right: 1rem;
   padding: 0;
 }
 
 .caution {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 /****************************************
@@ -224,36 +871,63 @@ Tables
 
 table,
 .table {
-  border-color: #dee2e6;
-  border-style: solid;
-  border-width: 1px;
-  font-size: 90%;
-  margin-bottom: 1em;
-  margin-top: 1em;
+  border: 1px solid var(--secondary-light);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
   padding: 0.5rem;
 }
 
+.stentry,
+.rowsep-1,
+thead,
 tr {
-  border-color: #dee2e6;
-  padding: 0.5rem;
+  border-bottom-color: var(--secondary-light);
 }
 
-td {
-  border-color: #dee2e6;
-  padding: 0.5rem;
+.chhead,
+.sthead {
+  border-top-color: var(--secondary-light);
+}
+
+.stentry {
+  border-right-color: var(--secondary-light);
 }
 
 th {
-  background-color: #f5f5f5;
-  padding: 0.5rem;
   text-align: left;
 }
 
 caption,
 figcaption {
-  color: #6c757d;
-  padding: 1em 0;
+  color: var(--code-color);
+  font-style: italic;
   text-align: left;
+}
+
+table caption {
+  padding-bottom: 1rem;
+}
+
+caption code,
+figcaption code,
+figcaption .filepath {
+  font-size: 0.875rem;
+}
+
+table code,
+table pre,
+table samp,
+table .cmdname,
+table .codeph,
+table .filepath,
+table .msgnum,
+table .option,
+table .parmname,
+table .varname {
+  color: var(--code-color);
+  font-family: var(--font-family-monospace);
+  font-size: 0.875rem;
 }
 
 /****************************************
@@ -263,27 +937,22 @@ Navigation
 /* ↓ nav-coderef ↓ */
 nav[role='toc'] {
   float: left;
+  margin-top: 0.5rem;
   width: 300px;
 }
 
 nav[role='toc'] li.active > a {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 /* ↑ end-nav-ref ↑ */
 
 nav[role='toc'] > ul {
-  margin-right: 2em;
+  margin-left: -0.4rem;
+  margin-right: 2rem;
 }
 
 nav[role='toc'] > ul li {
-  margin-bottom: 0.5em;
-  margin-top: 0.5em;
-}
-
-nav[role='toc'] > ul > li ul {
-  margin-bottom: 0.5em;
-  margin-left: 1.2em;
-  margin-top: 0.5em;
+  line-height: 1.25rem;
 }
 
 /****************************************
@@ -292,11 +961,11 @@ Glossary
 
 .glossAbbreviation,
 .glossAcronym {
-  color: #555;
-  font-size: 90%;
+  color: var(--code-color);
+  font-size: 0.9rem;
   font-style: italic;
-  font-weight: normal;
-  margin-left: 2em;
+  font-weight: var(--font-weight-bold);
+  margin-left: 1rem;
 }
 
 .glossAbbreviation::before,
@@ -308,6 +977,14 @@ Glossary
 .glossAcronym::after {
   content: '”';
 }
+
+.glossdef {
+  line-height: 1.5rem;
+}
+
+/****************************************
+Video link icons for DITA-OT Day talks
+****************************************/
 
 /* Append video icon to DITA-OT Day links in related links and link lists (but not in page footers) */
 a.link[href*='dita-ot_day']::after,


### PR DESCRIPTION
🎨 This PR replaces older custom CSS code in the HTML5 version of the distribution docs with styles based on  [almond.css](https://github.com/alvaromontoro/almond.css):

> Almond.CSS is a collection of class-less CSS styles to make simple websites look better.

This provides a more coherent baseline of modern style constructs that works well in recent browsers and approximates our Bootstrap output on the project website using Almond's built-in theming mechanisms like CSS variables and HSL colors.

The resulting output limits line length to a maximum width of `80ch` for a better reading experience on desktop displays. 🖥️ 

### Testing

    gradlew.bat -PditaHome=C:\path\to\dita-ot html