### PR TITLE
Update the docs to point to the container registry

### DIFF
--- a/samples/docker/Dockerfile
+++ b/samples/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest official DITA-OT image as parent:   ↓
-FROM docker.pkg.github.com/dita-ot/dita-ot/dita-ot:3.6
+FROM ghcr.io/dita-ot/dita-ot:3.6
 
 # Install a custom plug-in from a remote location:
 RUN dita --install https://github.com/infotexture/dita-bootstrap/archive/3.4.1.zip

--- a/topics/creating-docker-images.dita
+++ b/topics/creating-docker-images.dita
@@ -70,7 +70,7 @@
         /> directory:</p>
       <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> image build -t sample-docker-image:1.0 .
 Sending build context to Docker daemon  2.048kB
-Step 1/3 : FROM docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword keyref="maintenance-version"/>
+Step 1/3 : FROM ghcr.io/dita-ot/dita-ot:<keyword keyref="maintenance-version"/>
  ---> 9abb96827538
 Step 2/3 : RUN dita --install https://github.com/infotexture/dita-bootstrap/archive/3.4.1.zip
  ---> Running in d510f874cae0

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -33,12 +33,12 @@
         directories from the host machine.</p>
     </section>
     <prereq>
-      <p>To run the DITA-OT image, you will need to install Docker and log in to the GitHub Package Registry.
+      <p>To run the DITA-OT image, you will need to install Docker and be able to access the GitHub Container Registry.
         <ul>
           <li>To download Docker Desktop, you may be prompted to sign in with your Docker ID (or sign up to create
             one).</li>
-          <li>To retrieve docker images from the GitHub Package Registry, you will also need a GitHub account.</li>
-        </ul></p>
+        </ul>
+      </p>
     </prereq>
     <steps outputclass="multi-platform">
       <step>
@@ -65,42 +65,11 @@
         </choices>
       </step>
       <step>
-        <cmd>Log in to the GitHub Package Registry.</cmd>
-        <substeps>
-          <substep>
-            <cmd>In your
-              <xref href="https://github.com/settings/tokens" format="html" scope="external">GitHub profile
-                settings</xref>, create a new personal access token with the <codeph>read:packages</codeph> and
-                <codeph>repo</codeph> scopes.</cmd>
-            <info>For more information, see
-              <xref
-                href="https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line"
-                scope="external"
-                format="html"
-              >Creating a personal access token for the command line</xref>.</info>
-          </substep>
-          <substep>
-            <cmd>On the command line, run the <cmdname>docker</cmdname> command to log in with your GitHub
-              credentials.</cmd>
-            <stepxmp>
-              <codeblock outputclass="syntax-bash"><cmdname>docker</cmdname> login docker.pkg.github.com -u <varname
-                >USERNAME</varname> -p <varname>PASSWORD/TOKEN</varname></codeblock>
-            </stepxmp>
-            <info>For more information, see
-              <xref
-                href="https://help.github.com/en/articles/configuring-docker-for-use-with-github-package-registry#authenticating-to-github-package-registry"
-                scope="external"
-                format="html"
-              >Authenticating to GitHub Package Registry</xref>.</info>
-          </substep>
-        </substeps>
-      </step>
-      <step>
         <cmd>To build output, map a host directory to a container volume and specify options for the
             <cmdname>dita</cmdname> command.</cmd>
         <stepxmp>
           <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> run -it \
-  -v /Users/<varname>username</varname>/source:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:<keyword
+  -v /Users/<varname>username</varname>/source:/src ghcr.io/dita-ot/dita-ot:<keyword
               keyref="maintenance-version"
             /> \
   -i /src/input.ditamap \

--- a/topics/using-docker-images.dita
+++ b/topics/using-docker-images.dita
@@ -69,9 +69,7 @@
             <cmdname>dita</cmdname> command.</cmd>
         <stepxmp>
           <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> run -it \
-  -v /Users/<varname>username</varname>/source:/src ghcr.io/dita-ot/dita-ot:<keyword
-              keyref="maintenance-version"
-            /> \
+  -v /Users/<varname>username</varname>/source:/src ghcr.io/dita-ot/dita-ot:<keyword keyref="maintenance-version"/> \
   -i /src/input.ditamap \
   -o /src/out \
   -f html5 -v</codeblock>


### PR DESCRIPTION
The GitHub Package Registry has been superceded by the GitHub Container Registry. The location of the base Docker Image has therefore changed and needs to be updated in the Docs. GHCR is a public registry and does not require a log-in step