### PR TITLE
Pin Prettier plug-in version in GitHub action

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -28,6 +28,6 @@ jobs:
           # This part is also where you can pass other options, for example:
           prettier_options: --write **/*.{css,dita*,json,md,scss,xml,yaml,yml}
           # Install Prettier XML plugin
-          prettier_plugins: '@prettier/plugin-xml'
+          prettier_plugins: '@prettier/plugin-xml@v0.13.1'
           # Runs the action in dry mode. Files wont get changed and the action fails if there are unprettified files.
           dry: true


### PR DESCRIPTION
[prettier/plugin-xml](https://github.com/prettier/plugin-xml) dropped support for the `xmlSelfClosingSpace` option in [v1.0.0](https://github.com/prettier/plugin-xml/blob/main/CHANGELOG.md#100---2021-07-14), which causes formatting checks to fail until the extra space is added to self-closing elements.

This pins the plug-in version to the last version that supports the `xmlSelfClosingSpace` option to allow checks to complete successfully in the meantime.