### PR TITLE
Bump Saxon-HE to version 10.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ configurations {
 }
 
 dependencies {
-    // Use Saxon-HE 10.5 like DITA-OT, instead of the version that comes with `saxon-gradle`
-    saxon 'net.sf.saxon:Saxon-HE:10.5'
+    // Use Saxon-HE 10.6 like DITA-OT, instead of the version that comes with `saxon-gradle`
+    saxon 'net.sf.saxon:Saxon-HE:10.6'
 }
 
 import com.github.eerohele.DitaOtTask


### PR DESCRIPTION
## Description

Upgrade the Saxon-HE version in the Gradle build file to the recently released version 10.6.

## How Has This Been Tested?

Ran distribution build from https://github.com/dita-ot/dita-ot/pull/3803, build succeeds. ✅ 
