### PR TITLE
Fix double escaped XML code example

### DIFF
--- a/topics/pdf-plugin-structure_common-vars.dita
+++ b/topics/pdf-plugin-structure_common-vars.dita
@@ -29,7 +29,8 @@
       it clear how the variable text is being used.</p>
     <p>Some variables contain <xmlelement>param</xmlelement> elements which indicate parameter values that are
       substituted at publish time by the XSL. For example, a page number that is being generated as part of the
-      publishing process might be identified by &amp;lt;param ref-name="number"/&amp;gt; When editing or translating a
+      publishing process might be identified by <codeph
+      >&lt;param ref-name="number"/&gt;</codeph> When editing or translating a
       variable file, these should be included in the translation, though they can be moved and rearranged within the
         <xmlelement>variable</xmlelement> content as needed.</p>
     <p>The best way to start editing a custom variables file is by making a copy of the original from


### PR DESCRIPTION
## Description
Fix double escaped XML code example

## Motivation and Context

[Rendered page](https://www.dita-ot.org/dev/topics/pdf-plugin-structure_common-vars.html) shows up as

```
&lt;param ref-name="number"/&gt; 
```

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None


