### PR TITLE
Remove key definition list being written to temp directory

### DIFF
--- a/reference/preprocess-keyref.dita
+++ b/reference/preprocess-keyref.dita
@@ -5,8 +5,7 @@
   <title>Resolve key references (keyref)</title>
   <shortdesc>The <codeph>keyref</codeph> step examines all the keys that are defined in the DITA source and resolves the
     key references. Links that make use of keys are updated so that any <xmlatt>href </xmlatt>value is replaced by the
-    appropriate target; key-based text replacement is also performed, and the key definition list file is written to the
-    temporary directory. This step is implemented in Java.</shortdesc>
+    appropriate target; key-based text replacement is also performed. This step is implemented in Java.</shortdesc>
   <prolog>
     <metadata>
       <keywords>


### PR DESCRIPTION
@shaneataylor asked in Slack whether key definitions are still written to a file in a temporary directory, believing the information in the documentation to be outdated. @robander confirmed that the docs are incorrect and a temp file is  no longer used.

Signed-off-by: Lief Erickson <lief.erickson@gmail.com>
