### PR TITLE
Style additional domain elements in docs theme

### DIFF
--- a/samples/themes/dita-ot-docs-theme.yaml
+++ b/samples/themes/dita-ot-docs-theme.yaml
@@ -85,7 +85,6 @@ style:
     space-after: 8pt
   codeph:
     color: $brand-color-secondary
-    font-size: '0.9 * from-parent(font-size)'
   # ↓ set-cover-page ↓
   cover:
     background-image: dita-ot-logo-inverse.svg

--- a/samples/themes/dita-ot-docs-theme.yaml
+++ b/samples/themes/dita-ot-docs-theme.yaml
@@ -167,9 +167,11 @@ style:
   option:
     color: $brand-color-secondary
     font-family: $pdf2-font-monospaced
+    font-weight: bold
   parmname:
     color: $brand-color-primary
     font-family: $pdf2-font-monospaced
+    font-weight: bold
   section-title:
     color: $brand-color-secondary
   shortdesc:

--- a/samples/themes/dita-ot-docs-theme.yaml
+++ b/samples/themes/dita-ot-docs-theme.yaml
@@ -16,6 +16,7 @@ brand:
         caution: '#f8d7da'
         info: '#dce4f0'
         tip: '#d1e7dd'
+    xml-domain: '#639'
 # ↑ end-brand-colors ↑
 
 # ↓ add-font-stacks ↓
@@ -208,3 +209,9 @@ style:
     font-family: $pdf2-font-monospaced
     font-style: italic
     font-weight: bold
+  xmlatt:
+    color: $brand-color-xml-domain
+  xmlelement:
+    color: $brand-color-xml-domain
+  xmlnsname:
+    color: $brand-color-xml-domain

--- a/samples/themes/dita-ot-docs-theme.yaml
+++ b/samples/themes/dita-ot-docs-theme.yaml
@@ -164,6 +164,12 @@ style:
       background-color: $brand-color-note-background-tip
     warning:
       background-color: $brand-color-note-background-caution
+  option:
+    color: $brand-color-secondary
+    font-family: $pdf2-font-monospaced
+  parmname:
+    color: $brand-color-primary
+    font-family: $pdf2-font-monospaced
   section-title:
     color: $brand-color-secondary
   shortdesc:

--- a/samples/themes/dita-ot-docs-theme.yaml
+++ b/samples/themes/dita-ot-docs-theme.yaml
@@ -205,4 +205,6 @@ style:
     start-indent: 40pt
   varname:
     color: $brand-color-secondary
+    font-family: $pdf2-font-monospaced
     font-style: italic
+    font-weight: bold


### PR DESCRIPTION
Draft styling for https://github.com/jelovirt/pdf-generator/pull/90, which adds support for additional domains, including:

- programming domain
- markup domain
- UI domain
- XML domain

Not all of these elements are currently used in the docs, so to keep the theme file readable, we only style those elements that are currently used.

If new elements are added later, styling can be added as necessary.