### PR TITLE
Debug GitHub Actions

### DIFF
--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -1,0 +1,40 @@
+# This workflow builds changes to release tag and commits to website repo for release PR
+
+name: Debug generate website release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      dita-ot-version:
+        description: 'DITA-OT version'
+        required: true
+      docs-tag:
+        description: 'Docs tag'
+        required: true
+  repository_dispatch:
+    types: [release]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      WEBSITE_PLUGIN_BRANCH: 'master'
+      DITA_OT_VERSION: '4.0.1'
+    steps:
+      - name: Get variables
+        run: |
+          readonly TOKENS=($(echo $VERSION | tr '.' ' '))
+          echo "RELEASE=${TOKENS[0]}.${TOKENS[1]}" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "TAG=${{ github.event.inputs.docs-tag }}" >> $GITHUB_ENV
+        env:
+          VERSION: ${{ github.event.inputs.dita-ot-version }}
+      - name: Check out docs
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.TAG }}
+      - name: Debug
+        run: |
+          echo "${{ env.TAG }}"
+          echo "${{ env.RELEASE }}"
+          echo "${{ env.GITHUB_SHA_SHORT }}"


### PR DESCRIPTION
The workflow needs to be in the default branch in order to be callable from other repositories. This workflow will be removed once it's tested and the functionality is moved to `release.yml`.

