### PR TITLE
Test build with ndw/saxon-gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 import com.github.eerohele.DitaOtTask
-import com.github.eerohele.SaxonXsltTask
+import com.nwalsh.gradle.saxon.SaxonXsltTask
 
 def getPropertyOrDefault(String name, def defaultValue) {
     hasProperty(name) ? findProperty(name) : defaultValue

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.eerohele.dita-ot-gradle' version '0.7.1'
-    id 'com.github.eerohele.saxon-gradle' version '0.9.0-beta4'
+    id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.10.1'
 }
 
 // Specify Saxon version per https://github.com/eerohele/saxon-gradle/blob/master/README.md


### PR DESCRIPTION
Test docs build process with [ndw/saxon-gradle](https://github.com/ndw/saxon-gradle) per https://so.nwalsh.com/2023/03/04-saxon-gradle.

Our builds currently use the `SaxonXsltTask` in several places, so we’d have to refactor those to work with the new `ndw/saxon-gradle` if we want to use that for any reason:

https://github.com/dita-ot/docs/blob/develop/build.gradle#L42-L62
