### PR TITLE
Update theme reference from plug-in wiki

### DIFF
--- a/resources/theme/.gitrepo
+++ b/resources/theme/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/jelovirt/pdf-generator.wiki.git
 	branch = master
-	commit = 4c84af50e929eb2cf63a155143eed3ac86ea99a1
-	parent = 7bc3441a83a9c9ee663199db592ba5202ea22403
+	commit = 8aa491a8ba27666eedd46e4293de8955020a86e7
+	parent = 6122da3959a61d2fd8cf5a1959198189129ae9bc
 	method = merge
 	cmdver = 0.4.5

--- a/resources/theme/.gitrepo
+++ b/resources/theme/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/jelovirt/pdf-generator.wiki.git
 	branch = master
-	commit = 640e02901f21e69dd190389b97a145549b909bef
-	parent = 73974575422bc4c39a53a2a46135f0c58ab32b4f
+	commit = 4c84af50e929eb2cf63a155143eed3ac86ea99a1
+	parent = 7bc3441a83a9c9ee663199db592ba5202ea22403
 	method = merge
 	cmdver = 0.4.5

--- a/resources/theme/Styles.md
+++ b/resources/theme/Styles.md
@@ -257,25 +257,25 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `parml`
 
-Parml element.
+Parameter list element.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `plentry`
 
-Plentry element.
+Parameter list entry element.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `pt`
 
-Pt element.
+Parameter term element within a parameter list entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `pd`
 
-Pd element.
+Parameter definition element within a parameter list entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
@@ -377,7 +377,7 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 
 ### `apiname`
 
-Apiname element.
+API name element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
@@ -389,181 +389,181 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 
 ### `parmname`
 
-Parmname element.
+Parameter name element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `synph`
 
-Synph element.
+Syntax phrase element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `syntaxdiagram`
 
-Syntaxdiagram element.
+Syntax diagram element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `groupseq`
 
-Groupseq element.
+Group sequence element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `groupchoice`
 
-Groupchoice element.
+Group choice element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `groupcomp`
 
-Groupcomp element.
+Group composite element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `fragment`
 
-Fragment element.
+Syntax fragment element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `fragref`
 
-Fragref element.
+Syntax fragment reference element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `synblk`
 
-Synblk element.
+Syntax block element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `synnote`
 
-Synnote element.
+Syntax note element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `synnoteref`
 
-Synnoteref element.
+Syntax note reference element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `kwd`
 
-Kwd element.
+Syntax keyword element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `var`
 
-Var element.
+Syntax variable element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `oper`
 
-Oper element.
+Syntax operator element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `delim`
 
-Delim element.
+Syntax delimiter character element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `sep`
 
-Sep element.
+Syntax separator character element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `repsep`
 
-Repsep element.
+Syntax repeat separator character element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `b`
 
-B element.
+Bold highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `i`
 
-I element.
+Italic highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `u`
 
-U element.
+Underline highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `tt`
 
-Tt element.
+Teletype highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `sup`
 
-Sup element.
+Superscript highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `sub`
 
-Sub element.
+Subscript highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `line-through`
 
-Line-through element.
+Strikethrough highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `overline`
 
-Overline element.
+Overline highlighting element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `markupname`
 
-Markupname element.
+Named markup token element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `uicontrol`
 
-Uicontrol element.
+User interface control element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `wintitle`
 
-Wintitle element.
+Window or dialog title element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `menucascade`
 
-Menucascade element.
+Menu cascade element used to document a series of menu choices.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
 ### `shortcut`
 
-Shortcut element.
+Keyboard shortcut element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
@@ -575,7 +575,7 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 
 ### `filepath`
 
-Filepath element.
+File path element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
@@ -605,7 +605,7 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 
 ### `numcharref`
 
-XML character referenceelement.
+XML character reference element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 

--- a/resources/theme/Styles.md
+++ b/resources/theme/Styles.md
@@ -41,7 +41,7 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `h1`
 
-First level topic titles.
+First-level topic titles.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
@@ -49,7 +49,7 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `h2`
 
-Second level topic titles.
+Second-level topic titles.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
@@ -57,7 +57,7 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `h3`
 
-Third level topic titles.
+Third-level topic titles.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
@@ -65,7 +65,7 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `h4`
 
-Fourth level topic titles.
+Fourth-level topic titles.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
@@ -233,25 +233,25 @@ The styling properties that can be used are listed in [XSL fo:block](https://www
 
 ### `toc-1`
 
-First level TOC entry.
+First-level TOC entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `toc-2`
 
-Second level TOC entry.
+Second-level TOC entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `toc-3`
 
-Third level TOC entry.
+Third-level TOC entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
 ### `toc-4`
 
-Fourth level TOC entry.
+Fourth-level TOC entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 

--- a/resources/theme/Styles.md
+++ b/resources/theme/Styles.md
@@ -381,12 +381,6 @@ Apiname element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 
-### `codeph`
-
-Codeph element.
-
-The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
-
 ### `option`
 
 Option element.
@@ -576,12 +570,6 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 ### `screen`
 
 Screen element.
-
-The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
-
-### `filepath`
-
-Filepath element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
 

--- a/resources/theme/Styles.md
+++ b/resources/theme/Styles.md
@@ -255,6 +255,48 @@ Fourth level TOC entry.
 
 The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
 
+### `parml`
+
+Parml element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `plentry`
+
+Plentry element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `pt`
+
+Pt element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `pd`
+
+Pd element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `hazardstatement`
+
+Hazard statement element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `hazardstatement-label`
+
+Hazard statement label element.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
+### `hazardstatement-<type>-label`
+
+Label for hazard statement elements with `@type`.
+
+The styling properties that can be used are listed in [XSL fo:block](https://www.w3.org/TR/xsl11/#fo_block).
+
 ## Inline keys
 
 ### `link`
@@ -330,5 +372,263 @@ The styling properties that can be used are listed in [XSL fo:inline](https://ww
 ### `systemoutput`
 
 System output element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `apiname`
+
+Apiname element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `codeph`
+
+Codeph element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `option`
+
+Option element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `parmname`
+
+Parmname element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `synph`
+
+Synph element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `syntaxdiagram`
+
+Syntaxdiagram element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `groupseq`
+
+Groupseq element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `groupchoice`
+
+Groupchoice element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `groupcomp`
+
+Groupcomp element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `fragment`
+
+Fragment element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `fragref`
+
+Fragref element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `synblk`
+
+Synblk element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `synnote`
+
+Synnote element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `synnoteref`
+
+Synnoteref element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `kwd`
+
+Kwd element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `var`
+
+Var element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `oper`
+
+Oper element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `delim`
+
+Delim element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `sep`
+
+Sep element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `repsep`
+
+Repsep element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `b`
+
+B element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `i`
+
+I element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `u`
+
+U element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `tt`
+
+Tt element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `sup`
+
+Sup element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `sub`
+
+Sub element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `line-through`
+
+Line-through element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `overline`
+
+Overline element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `markupname`
+
+Markupname element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `uicontrol`
+
+Uicontrol element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `wintitle`
+
+Wintitle element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `menucascade`
+
+Menucascade element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `shortcut`
+
+Shortcut element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `screen`
+
+Screen element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `filepath`
+
+Filepath element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `filepath`
+
+Filepath element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `xmlelement`
+
+XML element element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `xmlatt`
+
+XML attribute element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `textentity`
+
+XML text entity element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `parameterentity`
+
+XML parameter entity element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `numcharref`
+
+XML character referenceelement.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `xmlnsname`
+
+XML namespace name element.
+
+The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).
+
+### `xmlpi`
+
+XML processing instruction element.
 
 The styling properties that can be used are listed in [XSL fo:inline](https://www.w3.org/TR/xsl11/#fo_inline).


### PR DESCRIPTION
## Description

Sync recent changes from https://github.com/jelovirt/pdf-generator/wiki/Styles (`9f2a314` & `4c84af5`), remove duplicate listings & edit descriptions.

These changes have been pushed back to the upstream wiki via [git-subrepo](https://github.com/ingydotnet/git-subrepo), but should not be merged here until a new version of the `com.elovirta.pdf` plug-in is released and bundled with DITA-OT.

> **Note**
>
> DITA-OT 4.0.2 includes `com.elovirta.pdf` version 0.6.0.
> 
> Version 0.6.1 was tagged Nov 12, 2022, but has not yet been published to the plug-in registry or bundled with a toolkit release.

cc/ @jelovirt 