### PR TITLE
HDITA and MDITA conditional processing guidance

### DIFF
--- a/topics/lwdita-input.dita
+++ b/topics/lwdita-input.dita
@@ -94,6 +94,13 @@
       <note type="attention">The HDITA map format is not yet supported. To include HDITA content, use an XDITA map or a
         DITA 1.3 map.</note>
     </section>
+    <section id="section_z1k_hmk_dxb">
+      <title>Using conditional processing in MDITA and HDITA</title>
+      <p>When you setup conditional processing in MDITA and HDITA, use the
+          <xmlatt>data-props</xmlatt> attribute name in the element that will have the conditional
+        processing applied. In the <filepath>.ditaval</filepath> file, however, use the
+          <xmlatt>props</xmlatt> attribute name.</p>
+    </section>
     <section>
       <title>Converting lightweight formats to DITA XML</title>
       <p>When you add LwDITA topics to a DITA publication, the content is temporarily converted to DITA in the

--- a/topics/lwdita-input.dita
+++ b/topics/lwdita-input.dita
@@ -94,7 +94,7 @@
       <note type="attention">The HDITA map format is not yet supported. To include HDITA content, use an XDITA map or a
         DITA 1.3 map.</note>
     </section>
-    <section id="section_z1k_hmk_dxb">
+    <section id="conditional-processing">
       <title>Using conditional processing in MDITA and HDITA</title>
       <p>When you setup conditional processing in MDITA and HDITA, use the
           <xmlatt>data-props</xmlatt> attribute name in the element that will have the conditional

--- a/topics/lwdita-input.dita
+++ b/topics/lwdita-input.dita
@@ -96,10 +96,9 @@
     </section>
     <section id="conditional-processing">
       <title>Using conditional processing in MDITA and HDITA</title>
-      <p>When you setup conditional processing in MDITA and HDITA, use the
-          <xmlatt>data-props</xmlatt> attribute name in the element that will have the conditional
-        processing applied. In the <filepath>.ditaval</filepath> file, however, use the
-          <xmlatt>props</xmlatt> attribute name.</p>
+      <p>When you set up conditional processing in MDITA and HDITA, use the <xmlatt>data-props</xmlatt> attribute in the
+        element that will have the conditional processing applied. In the <filepath>.ditaval</filepath> file, however,
+        use the <xmlatt>props</xmlatt> attribute.</p>
     </section>
     <section>
       <title>Converting lightweight formats to DITA XML</title>


### PR DESCRIPTION

Signed-off-by: Darrenn Jackson

## Description

Added a section to the LwDITA page to help LwDITA users successful apply conditional processing to their content. This new section explicitly tells users which attribute names to use in the HDITA/MDITA content and in the ditaval content, because these are different.

## Motivation and Context

For those testing/piloting MDITA specifically, when your conditional processing doesn't appear in the output, it's hard to know if it's because this feature isn't yet supported in DITA-OT, or if it's because you set it up wrong.

## How Has This Been Tested?

This is a docs change. Testing is N/A

## Type of Changes

Docs-only change. This does not introduce any xrefs, conrefs, keyrefs, or other linkages to the rest of the docs.


## Documentation and Compatibility

This doesn't require updates to user plug-ins.

## Checklist

No code testing required.

