### PR TITLE
Fix path to `plugin.properties`

### DIFF
--- a/parameters/plugin-properties-file.dita
+++ b/parameters/plugin-properties-file.dita
@@ -21,7 +21,7 @@
   </prolog>
   <refbody>
     <section>
-      <p>The file is located in the <filepath>lib/org.dita.dost.platform</filepath> directory of the DITA-OT
+      <p>The file is located in the <filepath>config/org.dita.dost.platform</filepath> directory of the DITA-OT
         installation and stores a cached version of the plug-in configuration used by the Java code.</p>
       <p>The contents of this file depend on the installed plug-ins. Each plug-in may contribute properties such as the
         path to the plug-in folder, supported extensions and print transformation types.</p>


### PR DESCRIPTION
## Description
Fix incorrect path to `plugin.properties`.

## Motivation and Context
The path was changed in DITA-OT 3.0.


## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

