### PR TITLE
Use latest version in release & dev docs workflows

### DIFF
--- a/.github/actions/render/action.yml
+++ b/.github/actions/render/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 'master'
   DITA_OT_VERSION:
     description: 'DITA-OT version used for rendering'
-    default: '4.0.1'
+    default: '4.1.2'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WEBSITE_PLUGIN_BRANCH: 'master'
-      DITA_OT_VERSION: '4.0.1'
+      DITA_OT_VERSION: '4.1.2'
     steps:
       - name: Parse arguments
         run: |


### PR DESCRIPTION
@jelovirt Our docs CI workflows have been stuck on a hard-coded version `4.0.1` for a while now.

This PR manually bumps them both to the latest version `4.1.2`, but we should explore options for automating or parameterizing this to always use the latest tagged version from the `master` branch.

Any ideas?