### PR TITLE
Remove image with --rm when running Docker

### DIFF
--- a/topics/creating-docker-images.dita
+++ b/topics/creating-docker-images.dita
@@ -96,7 +96,7 @@ Successfully tagged sample-docker-image:1.0
     <example>
       <title>Running the new container</title>
       <p>You can then start a container based on your new image:</p>
-      <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> container run -it \
+      <codeblock outputclass="syntax-bash">$ <cmdname>docker</cmdname> container run --rm \
   -v /path/to/dita-ot-dir/docsrc:/src sample-docker-image:1.0 \
   -i /src/userguide.ditamap \
   -o /src/out/dita-bootstrap \


### PR DESCRIPTION
## Description

Change Docker usage to use `--rm` option and remove redundant `-it` per #519.

Followup to #520.

## Motivation and Context

For most users, `--rm` is a better default.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_


