### PR TITLE
Explain the `--no-color` parameter

### DIFF
--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -431,6 +431,12 @@
           <pd>Verbose logging prints additional information to the console, including directory settings, effective
             values for Ant properties, input/output files, and informational messages to assist in troubleshooting.</pd>
         </plentry>
+        <plentry>
+          <pt>
+            <parmname>-no-color</parmname>
+          </pt>
+          <pd>By default, the DITA-OT outputs certain logging messages wrapped in special characters to get a colored output. If you prefer a clean output, you can set this parameter to deactivate the colored logging output.<codeblock>�[31m[move-meta] Failed to read file:/tmp/abc.dita: Failed to parse /tmp/abc.dita:Failed to read document: XML document structures must start and end within the same entity.�[0m</codeblock></pd>
+        </plentry>
       </parml>
     </section>
   </refbody>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -346,10 +346,10 @@
           <pt>
             <parmname>--no-color</parmname>
           </pt>
-          <pd>By default, the DITA-OT outputs certain logging messages wrapped in special characters to get a colored
-            output. If you prefer a clean output, you can set this parameter to deactivate the colored logging
-            output.<codeblock
-            >�[31m[move-meta] Failed to read file:/tmp/abc.dita: Failed to parse /tmp/abc.dita:Failed to read document: XML document structures must start and end within the same entity.�[0m</codeblock></pd>
+          <pd>By default, DITA-OT prints certain log messages to the console in color. In terminal environments that do
+            not support colored output, the ANSI color escape codes will be shown instead. To deactivate colored output,
+            pass the <parmname>--no-color</parmname> option to the <cmdname>dita</cmdname> command, or set the
+              <codeph>TERM=dumb</codeph> or <codeph>NO_COLOR</codeph> environment variables.</pd>
         </plentry>
         <plentry>
           <pt>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -344,6 +344,15 @@
         </plentry>
         <plentry>
           <pt>
+            <parmname>-no-color</parmname>
+          </pt>
+          <pd>By default, the DITA-OT outputs certain logging messages wrapped in special characters to get a colored
+            output. If you prefer a clean output, you can set this parameter to deactivate the colored logging
+            output.<codeblock
+            >�[31m[move-meta] Failed to read file:/tmp/abc.dita: Failed to parse /tmp/abc.dita:Failed to read document: XML document structures must start and end within the same entity.�[0m</codeblock></pd>
+        </plentry>
+        <plentry>
+          <pt>
             <parmname>--parameter</parmname>=<varname>value</varname></pt>
           <pt>
             <parmname>-D</parmname><varname>parameter</varname>=<varname>value</varname>
@@ -430,12 +439,6 @@
           </pt>
           <pd>Verbose logging prints additional information to the console, including directory settings, effective
             values for Ant properties, input/output files, and informational messages to assist in troubleshooting.</pd>
-        </plentry>
-        <plentry>
-          <pt>
-            <parmname>-no-color</parmname>
-          </pt>
-          <pd>By default, the DITA-OT outputs certain logging messages wrapped in special characters to get a colored output. If you prefer a clean output, you can set this parameter to deactivate the colored logging output.<codeblock>�[31m[move-meta] Failed to read file:/tmp/abc.dita: Failed to parse /tmp/abc.dita:Failed to read document: XML document structures must start and end within the same entity.�[0m</codeblock></pd>
         </plentry>
       </parml>
     </section>

--- a/parameters/dita-command-arguments.dita
+++ b/parameters/dita-command-arguments.dita
@@ -344,7 +344,7 @@
         </plentry>
         <plentry>
           <pt>
-            <parmname>-no-color</parmname>
+            <parmname>--no-color</parmname>
           </pt>
           <pd>By default, the DITA-OT outputs certain logging messages wrapped in special characters to get a colored
             output. If you prefer a clean output, you can set this parameter to deactivate the colored logging


### PR DESCRIPTION
## Description
Explain the `-no-color` parameter

## Motivation and Context
Parameter deactivates colored logging.

