### PR TITLE
Fix typos in documentation and code

### DIFF
--- a/reference/extended-functionality.dita
+++ b/reference/extended-functionality.dita
@@ -11,7 +11,7 @@
 
   <shortdesc>DITA-OT provides additional processing support beyond that which is mandated by the DITA specification.
     These extensions can be used to define character encodings or line ranges for code references, normalize
-    indendation, add line numbers or display whitespace characters in code blocks.</shortdesc>
+    indentation, add line numbers or display whitespace characters in code blocks.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/reference/markdown/Common-syntax.md
+++ b/reference/markdown/Common-syntax.md
@@ -163,7 +163,7 @@ Term
 <dl>
   <dlentry>
     <dt>Term</dt>
-    <dd>Defintion.</dd>
+    <dd>Definition.</dd>
   </dlentry>
 </dl>
 ```

--- a/reference/processing-structure.dita
+++ b/reference/processing-structure.dita
@@ -17,7 +17,7 @@
         <indexterm>XHTML</indexterm>
         <indexterm>PDF</indexterm>
         <indexterm>HTML5
-          <indexterm>preprocesing</indexterm></indexterm>
+          <indexterm>preprocessing</indexterm></indexterm>
         <indexterm>pipelines
           <indexterm>description of</indexterm></indexterm>
         <indexterm>pipelines

--- a/resources/dita-ot-doc.css
+++ b/resources/dita-ot-doc.css
@@ -844,7 +844,7 @@ h2 .codeph {
 }
 
 /****************************************
-Basic identation, padding, and margins
+Basic indentation, padding, and margins
 ****************************************/
 
 @media screen and (min-width: 992px) {

--- a/samples/concepts/tools.xml
+++ b/samples/concepts/tools.xml
@@ -15,7 +15,7 @@
       <li>Level</li>
       <li>Saws</li>
       <li>Drill</li>
-      <li>Air pressure guage</li>
+      <li>Air pressure gauge</li>
       <li>Spade</li>
       <li>Rake</li>
     </ul>

--- a/samples/taskbook/webtrouble.dita
+++ b/samples/taskbook/webtrouble.dita
@@ -3,7 +3,7 @@
 <!--  This file is part of the DITA Open Toolkit project. See the accompanying LICENSE file for applicable license.  -->
 <!-- (c) Copyright IBM Corp. 2004, 2005 All Rights Reserved. -->
 <task id="webtrouble" xml:lang="en-us">
-  <title>Troublshooting Web Server problems</title>
+  <title>Troubleshooting Web Server problems</title>
   <shortdesc>There are several things to try if your Web Server is not functioning properly.</shortdesc>
   <prolog>
     <metadata>

--- a/topics/building-output.dita
+++ b/topics/building-output.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
 <!--  This file is part of the DITA Open Toolkit project. See the accompanying LICENSE file for applicable license.  -->
-<task id="tranforming-dita-content">
+<task id="transforming-dita-content">
   <title>Building output</title>
   <shortdesc>You can use the <cmdname>dita</cmdname> command-line tool, Ant, or the Java API to transform DITA content
     to the various output formats that DITA Open Toolkit supports.</shortdesc>

--- a/topics/implement-saxon-extension-functions.dita
+++ b/topics/implement-saxon-extension-functions.dita
@@ -39,7 +39,7 @@
             <filepath>META-INF/services</filepath> in the compiled JAR that your plug-in provides. Each line of the file
           must be the name of a class that implements <codeph
           >net.sf.saxon.lib.ExtensionFunctionDefinition</codeph>: <codeblock>com.example.saxon.functions.Add
-com.example.saxon.functions.Substract</codeblock>
+com.example.saxon.functions.Subtract</codeblock>
           <p>You can create the file using <xmlelement>service</xmlelement> elements in an Ant
               <xmlelement>jar</xmlelement>
             task:<codeblock outputclass="language-xml">&lt;jar destfile="${basedir}/target/lib/example-saxon.jar">

--- a/topics/plugin-configfile.dita
+++ b/topics/plugin-configfile.dita
@@ -10,7 +10,7 @@
     <metadata>
       <keywords>
         <indexterm>plug-ins
-          <indexterm>identfiers</indexterm></indexterm>
+          <indexterm>identifiers</indexterm></indexterm>
         <indexterm>plug-ins
           <indexterm><filepath>plugin.xml</filepath></indexterm></indexterm>
         <indexterm>metadata
@@ -82,7 +82,7 @@
             </simpletable>
             <p id="extension-point-ids">Like plug-in identifiers, extension point identifiers are composed of one or
               more dot-delimited tokens.</p>
-            <note id="entension-point-ids-note">Extension point identifiers should begin with the identifier of the
+            <note id="extension-point-ids-note">Extension point identifiers should begin with the identifier of the
               defining plug-in and append one or more tokens, for example, <codeph>org.dita.example.pre</codeph>.</note>
             <fig>
               <title>Sample <xmlelement>extension-point</xmlelement> element</title>


### PR DESCRIPTION
All of them were found using `typos`.
