### PR TITLE
Add author to GHA generated PR commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
             * dita-ot/org.dita-ot.html (${{ env.WEBSITE_PLUGIN_BRANCH }})
           commit-message: 'Update ‘${{ env.RELEASE }}’ docs for ${{ env.RELEASE_VERSION }}'
           committer: 'DITA-OT Bot <ditaotbot@gmail.com>'
+          author: 'DITA-OT Bot <ditaotbot@gmail.com>'
           signoff: true
           token: ${{ secrets.DOCS_RELEASE_TOKEN }}
           path: website
@@ -139,6 +140,7 @@ jobs:
             Update docs GitHub Actions for ${{ env.RELEASE_VERSION }}.
           commit-message: 'Update GitHub Actions for ${{ env.RELEASE_VERSION }}'
           committer: 'DITA-OT Bot <ditaotbot@gmail.com>'
+          author: 'DITA-OT Bot <ditaotbot@gmail.com>'
           signoff: true
           token: ${{ secrets.DOCS_RELEASE_TOKEN }}
           labels: |


### PR DESCRIPTION
## Description
Add `author` to PR commits generated by GitHub Actions.

## Motivation and Context
Fix mismatch between `author` and sign-off.
