### PR TITLE
reorder/rename pdf-themes topics to make them less confusing

### DIFF
--- a/topics/pdf-themes.ditamap
+++ b/topics/pdf-themes.ditamap
@@ -4,7 +4,6 @@
 <map>
   <title>PDF themes</title>
   <topicref keyref="pdf-themes">
-    <topicref keyref="sample-pdf-theme"/>
     <topicref keyref="page-settings"/>
     <topicref keyref="header-and-footer"/>
     <topicref keyref="styles">
@@ -14,5 +13,6 @@
     <topicref keyref="variables"/>
     <topicref keyref="extending-themes"/>
     <topicref keyref="syntactic-sugar"/>
+    <topicref keyref="sample-pdf-theme"/>
   </topicref>
 </map>

--- a/topics/sample-pdf-theme.dita
+++ b/topics/sample-pdf-theme.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <!--  This file is part of the DITA Open Toolkit project. See the accompanying LICENSE file for applicable license.  -->
 <concept id="ID">
-  <title>Sample theme file</title>
+  <title>Examples</title>
   <shortdesc>Theme files can be written in either
     <xref keyref="json"/> or
     <xref keyref="yaml-home"/> format. The <filepath>docsrc/samples/themes</filepath> folder in the DITA-OT installation


### PR DESCRIPTION
## Description
Move the examples from the front to the end of PDF themes.

## Motivation and Context
I found this part confusing. I'd rather have the examples at the end, so that new readers are guided through the features first.

## Type of Changes
Editorial change

## Documentation and Compatibility
This is a documentation change