### PR TITLE
Add .mailmap file to collate AUTHORS list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Ced Porter <ed.porter.iii@gmail.com> cedporter <ed.porter.iii@gmail.com>
+Dávid Bertalan <16006640+thendarion@users.noreply.github.com> David Bertalan <16006640+thendarion@users.noreply.github.com>
+Edit Koselak <61583300+EditKoselak@users.noreply.github.com> EditKoselak <61583300+EditKoselak@users.noreply.github.com>
+Eero Helenius <eero.helenius@kapsi.fi> Eero Helenius <eero.helenius@citec.com>
+Eero Helenius <eero.helenius@kapsi.fi> Eero Helenius <eerohele@users.noreply.github.com>
+Jeremy Jeanne <jeremy.jeanne@4dconcept.fr> Jeremy Jeanne 🐝☕ 🐍 🐦‍⬛🔥 <jyjeanne@gmail.com>
+Rene Mjartan <rene_mjartan@yahoo.com> Rene <rene_mjartan@yahoo.com>
+Robert D. Anderson <gorodki@gmail.com> Robert Anderson <robert.dan.anderson@oracle.com>
+Robert D. Anderson <gorodki@gmail.com> Robert D Anderson <robander@us.ibm.com>
+Robert D. Anderson <gorodki@gmail.com> Robert D Anderson <robert.dan.anderson@oracle.com>
+Stefan Jung <stefan.eike@mailbox.org> Stefan Eike <stefan.eike@dometic.com>
+Stefan Jung <stefan.eike@mailbox.org> Stefan Eike <stefan.eike@mailbox.org>
+Stefan Jung <stefan.eike@mailbox.org> Stefan Jung <stefan.jung@Dometic.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,30 +1,29 @@
-Roger Sheen <roger@infotexture.net>
-Jarno Elovirta <jarno@elovirta.com>
-dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-Lief Erickson <lief.erickson@gmail.com>
-Robert D. Anderson <gorodki@gmail.com>
-Kristen James Eberlein <kris@eberleinconsulting.com>
-Shane Taylor <shane@taylortext.com>
-Eero Helenius <eero.helenius@kapsi.fi>
-Stefan Eike <stefan.eike@mailbox.org>
-Edit Koselak <edit.koselak@nokia.com>
-Eliot Kimber <drmacro@yahoo.com>
-Jason Fox <jason.fox@fiware.org>
-Mark Giffin <m1879@earthlink.net>
-Darrenn Jackson <darrenn.jackson@gmail.com>
-George Bina <george@oxygenxml.com>
-Jeremy Jeanne <jeremy.jeanne@4dconcept.fr>
-bbg3 <bbg3@users.noreply.github.com>
-Ced Porter <ed.porter.iii@gmail.com>
-Dávid Bertalan <16006640+thendarion@users.noreply.github.com>
-Erlend Leganger <erlend.leganger@gmail.com>
-François Violette <francoisviolette@gmail.com>
-Garrett Guillotte <gguillotte@users.noreply.github.com>
-Heston Hoffman <heston.hoffman@puppet.com>
-Lionel Moizeau <lionel.moizeau@gmail.com>
-Nicolas Delobel <37327034+Nico-Amplexor@users.noreply.github.com>
-Quick van Rijt <41584738+qvrijt@users.noreply.github.com>
-Radu Coravu <radu_coravu@oxygenxml.com>
-Rene Mjartan <rene_mjartan@yahoo.com>
-Stefan Weil <sw@weilnetz.de>
-Ursula Kallio <ursula.kallio@gmail.com>
+Roger Sheen
+Jarno Elovirta
+Lief Erickson
+Robert D. Anderson
+Kristen James Eberlein
+Shane Taylor
+Eero Helenius
+Stefan Jung
+Edit Koselak
+Eliot Kimber
+Jason Fox
+Mark Giffin
+Darrenn Jackson
+George Bina
+Jeremy Jeanne
+bbg3
+Ced Porter
+Dávid Bertalan
+Erlend Leganger
+François Violette
+Garrett Guillotte
+Heston Hoffman
+Lionel Moizeau
+Nicolas Delobel
+Quick van Rijt
+Radu Coravu
+Rene Mjartan
+Stefan Weil
+Ursula Kallio

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,30 @@
+Roger Sheen <roger@infotexture.net>
+Jarno Elovirta <jarno@elovirta.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Lief Erickson <lief.erickson@gmail.com>
+Robert D. Anderson <gorodki@gmail.com>
+Kristen James Eberlein <kris@eberleinconsulting.com>
+Shane Taylor <shane@taylortext.com>
+Eero Helenius <eero.helenius@kapsi.fi>
+Stefan Eike <stefan.eike@mailbox.org>
+Edit Koselak <edit.koselak@nokia.com>
+Eliot Kimber <drmacro@yahoo.com>
+Jason Fox <jason.fox@fiware.org>
+Mark Giffin <m1879@earthlink.net>
+Darrenn Jackson <darrenn.jackson@gmail.com>
+George Bina <george@oxygenxml.com>
+Jeremy Jeanne <jeremy.jeanne@4dconcept.fr>
+bbg3 <bbg3@users.noreply.github.com>
+Ced Porter <ed.porter.iii@gmail.com>
+Dávid Bertalan <16006640+thendarion@users.noreply.github.com>
+Erlend Leganger <erlend.leganger@gmail.com>
+François Violette <francoisviolette@gmail.com>
+Garrett Guillotte <gguillotte@users.noreply.github.com>
+Heston Hoffman <heston.hoffman@puppet.com>
+Lionel Moizeau <lionel.moizeau@gmail.com>
+Nicolas Delobel <37327034+Nico-Amplexor@users.noreply.github.com>
+Quick van Rijt <41584738+qvrijt@users.noreply.github.com>
+Radu Coravu <radu_coravu@oxygenxml.com>
+Rene Mjartan <rene_mjartan@yahoo.com>
+Stefan Weil <sw@weilnetz.de>
+Ursula Kallio <ursula.kallio@gmail.com>


### PR DESCRIPTION
## Description

🚧 WIP to map author and committer names and email addresses to canonical real names and email addresses.

https://git-scm.com/docs/gitmailmap

> [!IMPORTANT]  
> This won't be merged as is.
