### PR TITLE
Bump jyjeanne/dita-ot-gradle from 2.8.2 to 2.8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.2'
+    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.3'
 }
 
 import org.gradle.api.DefaultTask

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.4'
+    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.5'
 }
 
 import org.gradle.api.DefaultTask

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.3'
+    id 'io.github.jyjeanne.dita-ot-gradle' version '2.8.4'
 }
 
 import org.gradle.api.DefaultTask


### PR DESCRIPTION
## Description

Upgrade [jyjeanne/dita-ot-gradle](https://github.com/jyjeanne/dita-ot-gradle/) to latest version [v2.8.3](https://github.com/jyjeanne/dita-ot-gradle/releases/tag/v2.8.3)

## How Has This Been Tested?

Bump version in docs build script, run default `dist` task.
